### PR TITLE
Fix 'interface {} is nil' error

### DIFF
--- a/charts/k8s-ephemeral-storage-metrics/templates/DeployType.yaml
+++ b/charts/k8s-ephemeral-storage-metrics/templates/DeployType.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: {{ .Release.Name }}
+  {{- if .Values.deploy_annotations }}
+  annotations:
+    {{- .Values.deploy_annotations | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   {{- if eq .Values.deploy_type "Deployment" }}
   replicas: 1
@@ -20,7 +24,7 @@ spec:
       serviceAccountName: k8s-ephemeral-storage-metrics
       containers:
         - name: metrics
-          image: {{ .Values.image | default "registry.lab.com/k8s-ephemeral-storage-metrics" }}
+          image: {{ .Values.image | default "placeholder" }}
           resources:
             limits:
               memory: 200Mi

--- a/charts/k8s-ephemeral-storage-metrics/templates/DeployType.yaml
+++ b/charts/k8s-ephemeral-storage-metrics/templates/DeployType.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: {{ .Values.deploy_type  }}
+kind: {{ .Values.deploy_type | default "DaemonSet" }}
 metadata:
   name: k8s-ephemeral-storage-metrics
   namespace: {{ .Release.Namespace }}
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: k8s-ephemeral-storage-metrics
       containers:
         - name: metrics
-          image: {{ .Values.image }}
+          image: {{ .Values.image | default "registry.lab.com/k8s-ephemeral-storage-metrics" }}
           resources:
             limits:
               memory: 200Mi
@@ -29,13 +29,13 @@ spec:
               memory: 200Mi
           ports:
             - name: http
-              containerPort: 9100
+              containerPort: {{ .Values.metrics_port | default "9100" }}
               protocol: TCP
           livenessProbe:
             failureThreshold: 10
             httpGet:
               path: /metrics
-              port: 9100
+              port: {{ .Values.metrics_port | default "9100" }}
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -45,16 +45,21 @@ spec:
             failureThreshold: 10
             httpGet:
               path: /metrics
-              port: 9100
+              port: {{ .Values.metrics_port | default "9100" }}
               scheme: HTTP
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           env:
             - name: LOG_LEVEL
-              value: "{{ .Values.log_level }}"
+              value: "{{ .Values.log_level | default "info" }}"
             - name: CURRENT_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-
+            - name: METRICS_PORT
+              value: "{{ .Values.metrics_port | default "9100" }}"
+            - name: CURRENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name


### PR DESCRIPTION
1. Added skipping the scrape of the exporter pod - it caused an error in the description
2. Added defaults to deploy template variables
3. Added a variable to customize exporter's port