### PR TITLE
Add pod_namespace to the metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module k8s-ephemeral-storage-metrics
 go 1.19
 
 require (
-	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.13.0
 	github.com/rs/zerolog v1.28.0
 	k8s.io/client-go v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,6 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/main.go
+++ b/main.go
@@ -83,6 +83,8 @@ func getMetrics() {
 		[]string{
 			// name of pod for Ephemeral Storage
 			"pod_name",
+			// namespace of pod for Ephemeral Storage
+			"pod_namespace",
 			// Name of Node where pod is placed.
 			"node_name",
 		},
@@ -104,13 +106,14 @@ func getMetrics() {
 
 		nodeName := raw["node"].(map[string]interface{})["nodeName"].(string)
 		for _, element := range raw["pods"].([]interface{}) {
-
-			podName := element.(map[string]interface{})["podRef"].(map[string]interface{})["name"].(string)
+			ref := element.(map[string]interface{})["podRef"].(map[string]interface{})
+			podName := ref["name"].(string)
+			podNamespace := ref["namespace"].(string)
 			usedBytes := element.(map[string]interface{})["ephemeral-storage"].(map[string]interface{})["usedBytes"].(float64)
 
-			opsQueued.With(prometheus.Labels{"pod_name": podName, "node_name": nodeName}).Set(usedBytes)
+			opsQueued.With(prometheus.Labels{"pod_namespace": podNamespace, "pod_name": podName, "node_name": nodeName}).Set(usedBytes)
 
-			log.Debug().Msg(fmt.Sprintf("pod %s on %s with usedBytes: %s", podName, nodeName, usedBytes))
+			log.Debug().Msg(fmt.Sprintf("pod %s/%s on %s with usedBytes: %f", podNamespace, podName, nodeName, usedBytes))
 		}
 
 		time.Sleep(15 * time.Second)

--- a/main.go
+++ b/main.go
@@ -148,9 +148,10 @@ func main() {
 	go getMetrics()
 	port := getEnv("METRICS_PORT", "9100")
 	http.Handle("/metrics", promhttp.Handler())
+	log.Info().Msg(fmt.Sprintf("Starting server listening on :%s", port))
 	err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
 	if err != nil {
-		log.Error().Msg(fmt.Sprintf("Listener Falied : %s\n", err.Error()))
+		log.Error().Msg(fmt.Sprintf("Listener Failed : %s\n", err.Error()))
 		panic(err.Error())
 	}
 


### PR DESCRIPTION
Hi @jmcgrath207, firstly, thanks for the useful tool!

We just miss information about the namespace of the pod, so this PR adds it as `pod_name`.

Tested locally and works fine

```
ephemeral_storage_pod_usage{node_name=row-x-y1-40c48r600d-b6675bfc5-c75mh",pod_name="calico-node-ghljj",pod_namespace="calico-system"} 4.069376e+07
```

Additionally, I just added tiny changes in logging and `go mod tidy` in separate commits. 

