### PR TITLE
Added ephemeral_storage_container_limit_percentage metric

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,11 @@ name: e2e
 
 on:
   push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [opened, reopened]
+
 
 jobs:
   e2e:

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ release-helm:
 	cd ..
 
 release: github_login release-docker release-helm helm-docs
-	# ex. make VERSION=1.3.1 release
+	# ex. make VERSION=1.4.0 release
 
 release-github: github_login
-	# ex. make VERSION=1.3.1 release-github
+	# ex. make VERSION=1.4.0 release-github
 	gh release create ${VERSION} --generate-notes
 	gh release upload ${VERSION} "chart/k8s-ephemeral-storage-metrics-${VERSION}.tgz"
 	rm chart/k8s-ephemeral-storage-metrics-*.tgz

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | dev.enabled | bool | `false` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics"` |  |
-| image.tag | string | `"1.3.1"` |  |
+| image.tag | string | `"1.4.0"` |  |
 | interval | int | `15` | Polling node rate for exporter |
 | log_level | string | `"info"` |  |
 | max_node_concurrency | int | `10` | Max number of concurrent query requests to the kubernetes API. |
-| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true}` | Set metrics you want to enable |
+| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true}` | Set metrics you want to enable |
 | metrics.adjusted_polling_rate | bool | `false` | Create the ephemeral_storage_adjusted_polling_rate metrics to report Adjusted Poll Rate in milliseconds. Typically used for testing. |
+| metrics.ephemeral_storage_container_limit_percentage | bool | `true` | Percentage of ephemeral storage used by a container in a pod |
 | metrics.ephemeral_storage_node_available | bool | `true` | Available ephemeral storage for a node |
 | metrics.ephemeral_storage_node_capacity | bool | `true` | Capacity of ephemeral storage for a node |
 | metrics.ephemeral_storage_node_percentage | bool | `true` | Percentage of ephemeral storage used on a node |

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k8s-ephemeral-storage-metrics
-version: 1.3.1
-appVersion: 1.3.1
+version: 1.4.0
+appVersion: 1.4.0
 kubeVersion: ">=1.21.0-0"
 description: Ephemeral storage metrics for prometheus operator.
 home: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics

--- a/chart/README.md
+++ b/chart/README.md
@@ -14,12 +14,13 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | dev.enabled | bool | `false` |  |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics"` |  |
-| image.tag | string | `"1.3.1"` |  |
+| image.tag | string | `"1.4.0"` |  |
 | interval | int | `15` | Polling node rate for exporter |
 | log_level | string | `"info"` |  |
 | max_node_concurrency | int | `10` | Max number of concurrent query requests to the kubernetes API. |
-| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true}` | Set metrics you want to enable |
+| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true}` | Set metrics you want to enable |
 | metrics.adjusted_polling_rate | bool | `false` | Create the ephemeral_storage_adjusted_polling_rate metrics to report Adjusted Poll Rate in milliseconds. Typically used for testing. |
+| metrics.ephemeral_storage_container_limit_percentage | bool | `true` | Percentage of ephemeral storage used by a container in a pod |
 | metrics.ephemeral_storage_node_available | bool | `true` | Available ephemeral storage for a node |
 | metrics.ephemeral_storage_node_capacity | bool | `true` | Capacity of ephemeral storage for a node |
 | metrics.ephemeral_storage_node_percentage | bool | `true` | Percentage of ephemeral storage used on a node |

--- a/chart/index.yaml
+++ b/chart/index.yaml
@@ -8,6 +8,28 @@ entries:
           url: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
       artifacthub.io/prerelease: "false"
     apiVersion: v2
+    appVersion: 1.4.0
+    created: "2023-12-03T19:08:19.344214729-06:00"
+    description: Ephemeral storage metrics for prometheus operator.
+    digest: b671c1ba3e95f738d2d8014e4510472701911affdf6787bd0461806cea2475c0
+    home: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+    keywords:
+    - kubernetes
+    - metrics
+    kubeVersion: '>=1.21.0-0'
+    name: k8s-ephemeral-storage-metrics
+    sources:
+    - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+    urls:
+    - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/releases/download/1.4.0/k8s-ephemeral-storage-metrics-1.4.0.tgz
+    version: 1.4.0
+  - annotations:
+      artifacthub.io/license: MIT
+      artifacthub.io/links: |
+        - name: Documentation
+          url: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+      artifacthub.io/prerelease: "false"
+    apiVersion: v2
     appVersion: 1.3.1
     created: "2023-11-27T17:18:17.453989503-06:00"
     description: Ephemeral storage metrics for prometheus operator.
@@ -199,4 +221,4 @@ entries:
     urls:
     - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/releases/download/1.0.0/k8s-ephemeral-storage-metrics-1.0.0.tgz
     version: 1.0.0
-generated: "2023-11-27T17:18:17.45365655-06:00"
+generated: "2023-12-03T19:08:19.343211858-06:00"

--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -81,6 +81,10 @@ spec:
             - name: EPHEMERAL_STORAGE_NODE_PERCENTAGE
               value: "{{ .Values.metrics.ephemeral_storage_node_percentage }}"
               {{- end }}
+              {{- if .Values.metrics.ephemeral_storage_node_percentage }}
+            - name: EPHEMERAL_STORAGE_CONTAINER_LIMIT_PERCENTAGE
+              value: "{{ .Values.metrics.ephemeral_storage_container_limit_percentage }}"
+              {{- end }}
               {{- if .Values.metrics.adjusted_polling_rate }}
             - name: ADJUSTED_POLLING_RATE
               value: "{{ .Values.metrics.adjusted_polling_rate }}"

--- a/chart/templates/RBAC.yaml
+++ b/chart/templates/RBAC.yaml
@@ -7,8 +7,8 @@ metadata:
   {{- include "chart.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["nodes","nodes/proxy"]
-    verbs: ["get","list"]
+    resources: ["nodes","nodes/proxy", "pods"]
+    verbs: ["get","list", "watch"]
 
 ---
 

--- a/chart/templates/test_deployments.yaml
+++ b/chart/templates/test_deployments.yaml
@@ -18,6 +18,11 @@ spec:
         - image: local.io/local/shrink-test:latest
           imagePullPolicy: Never
           name: shrink-test
+          resources:
+            requests:
+              ephemeral-storage: "1Mi"
+            limits:
+              ephemeral-storage: "5Mi"
 
 ---
 
@@ -40,4 +45,9 @@ spec:
         - image: local.io/local/grow-test:latest
           imagePullPolicy: Never
           name: grow-test
+          resources:
+            requests:
+              ephemeral-storage: "1Mi"
+            limits:
+              ephemeral-storage: "5Mi"
  {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,10 +1,12 @@
 image:
   repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
-  tag: 1.3.1
+  tag: 1.4.0
   imagePullPolicy: IfNotPresent
 
 # -- Set metrics you want to enable
 metrics:
+  # -- Percentage of ephemeral storage used by a container in a pod
+  ephemeral_storage_container_limit_percentage: true
   # -- Current ephemeral byte usage of pod
   ephemeral_storage_pod_usage: true
   # -- Available ephemeral storage for a node

--- a/tests/e2e/deployment_test.go
+++ b/tests/e2e/deployment_test.go
@@ -107,6 +107,19 @@ func checkPrometheus(checkSlice []string) {
 
 }
 
+func WatchContainerPercentage() {
+	status := 0
+	re := regexp.MustCompile(`ephemeral_storage_container_limit_percentage{container="grow-test",node_name="ephemeral-metrics-cluster-worker".+,pod_namespace="ephemeral-metrics"}\s+(.+)`)
+	output := requestPrometheusString()
+	match := re.FindAllStringSubmatch(output, -1)
+	floatValue, _ := strconv.ParseFloat(match[0][1], 64)
+	if floatValue < 100.0 {
+		status = 1
+	}
+	gomega.Expect(status).Should(gomega.Equal(1))
+
+}
+
 func WatchNodePercentage() {
 	status := 0
 	re := regexp.MustCompile(`ephemeral_storage_node_percentage\{node_name="ephemeral-metrics-cluster-control-plane"}\s+(.+)`)
@@ -195,7 +208,8 @@ var _ = ginkgo.Describe("Test Metrics\n", func() {
 				"ephemeral_storage_node_capacity",
 				"ephemeral_storage_node_percentage",
 				"pod_name=\"k8s-ephemeral-storage", "ephemeral_storage_adjusted_polling_rate",
-				"node_name=\"ephemeral-metrics-cluster-worker", "node_name=\"ephemeral-metrics-cluster-control-plane")
+				"node_name=\"ephemeral-metrics-cluster-worker", "node_name=\"ephemeral-metrics-cluster-control-plane",
+				"ephemeral_storage_container_limit_percentage")
 			checkPrometheus(checkSlice)
 		})
 	})
@@ -215,6 +229,11 @@ var _ = ginkgo.Describe("Test Metrics\n", func() {
 	ginkgo.Context("Test ephemeral_storage_node_percentage\n", func() {
 		ginkgo.Specify("\nMake sure percentage is not over 100", func() {
 			WatchNodePercentage()
+		})
+	})
+	ginkgo.Context("Test ephemeral_storage_node_percentage\n", func() {
+		ginkgo.Specify("\nMake sure percentage is not over 100", func() {
+			WatchContainerPercentage()
 		})
 	})
 })


### PR DESCRIPTION
```
metrics:
  # -- Percentage of ephemeral storage used by a container in a pod
  ephemeral_storage_container_limit_percentage: true
  
```

Looks at Pod Manifest for these values. If not found, it will report the node ephemeral storage available for the container.

```yaml
          resources:
            requests:
              ephemeral-storage: "1Ki"
            limits:
              ephemeral-storage: "5Ki"
```


For issue https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/issues/41#issuecomment-1837366252