### PR TITLE
Public grow and shrinking test images

### DIFF
--- a/DockerfileTestGrow
+++ b/DockerfileTestGrow
@@ -1,5 +1,6 @@
 FROM ubuntu:22.04
 RUN apt-get update -y && apt-get install watch
+LABEL org.opencontainers.image.source="https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics"
 
 COPY tests/scripts/growing_epheremal_storage.sh growing_epheremal_storage.sh
 

--- a/DockerfileTestShrink
+++ b/DockerfileTestShrink
@@ -1,5 +1,6 @@
 FROM ubuntu:22.04
 RUN apt-get update -y && apt-get install watch
+LABEL org.opencontainers.image.source="https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics"
 
 COPY tests/scripts/shrinking_epheremal_storage.sh shrinking_epheremal_storage.sh
 

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ release-helm:
 	cd ..
 
 release: github_login release-docker release-helm helm-docs
-	# ex. make VERSION=1.4.0 release
+	# ex. make VERSION=1.4.1 release
 
 release-github: github_login
-	# ex. make VERSION=1.4.0 release-github
+	# ex. make VERSION=1.4.1 release-github
 	gh release create ${VERSION} --generate-notes
 	gh release upload ${VERSION} "chart/k8s-ephemeral-storage-metrics-${VERSION}.tgz"
 	rm chart/k8s-ephemeral-storage-metrics-*.tgz

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deploy_type | string | `"Deployment"` | Set as Deployment for single controller to query all nodes or Daemonset |
-| dev.enabled | bool | `false` |  |
+| dev | object | `{"enabled":false,"image":{"imagePullPolicy":"IfNotPresent"}}` | For local development of kind and/or deploy grow and shrink test pods |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics"` |  |
-| image.tag | string | `"1.4.0"` |  |
+| image.tag | string | `"1.4.1"` |  |
 | interval | int | `15` | Polling node rate for exporter |
 | log_level | string | `"info"` |  |
 | max_node_concurrency | int | `10` | Max number of concurrent query requests to the kubernetes API. |

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k8s-ephemeral-storage-metrics
-version: 1.4.0
-appVersion: 1.4.0
+version: 1.4.1
+appVersion: 1.4.1
 kubeVersion: ">=1.21.0-0"
 description: Ephemeral storage metrics for prometheus operator.
 home: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics

--- a/chart/README.md
+++ b/chart/README.md
@@ -11,10 +11,10 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | deploy_type | string | `"Deployment"` | Set as Deployment for single controller to query all nodes or Daemonset |
-| dev.enabled | bool | `false` |  |
+| dev | object | `{"enabled":false,"image":{"imagePullPolicy":"IfNotPresent"}}` | For local development of kind and/or deploy grow and shrink test pods |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics"` |  |
-| image.tag | string | `"1.4.0"` |  |
+| image.tag | string | `"1.4.1"` |  |
 | interval | int | `15` | Polling node rate for exporter |
 | log_level | string | `"info"` |  |
 | max_node_concurrency | int | `10` | Max number of concurrent query requests to the kubernetes API. |

--- a/chart/index.yaml
+++ b/chart/index.yaml
@@ -8,6 +8,28 @@ entries:
           url: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
       artifacthub.io/prerelease: "false"
     apiVersion: v2
+    appVersion: 1.4.1
+    created: "2023-12-06T22:08:48.40178216-06:00"
+    description: Ephemeral storage metrics for prometheus operator.
+    digest: ce17c13c544dd8dc8227bacc96f5bd4dc39ce67e2fa33f3397947cc992ff8300
+    home: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+    keywords:
+    - kubernetes
+    - metrics
+    kubeVersion: '>=1.21.0-0'
+    name: k8s-ephemeral-storage-metrics
+    sources:
+    - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+    urls:
+    - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/releases/download/1.4.1/k8s-ephemeral-storage-metrics-1.4.1.tgz
+    version: 1.4.1
+  - annotations:
+      artifacthub.io/license: MIT
+      artifacthub.io/links: |
+        - name: Documentation
+          url: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+      artifacthub.io/prerelease: "false"
+    apiVersion: v2
     appVersion: 1.4.0
     created: "2023-12-03T19:08:19.344214729-06:00"
     description: Ephemeral storage metrics for prometheus operator.
@@ -221,4 +243,4 @@ entries:
     urls:
     - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/releases/download/1.0.0/k8s-ephemeral-storage-metrics-1.0.0.tgz
     version: 1.0.0
-generated: "2023-12-03T19:08:19.343211858-06:00"
+generated: "2023-12-06T22:08:48.401412493-06:00"

--- a/chart/templates/test_deployments.yaml
+++ b/chart/templates/test_deployments.yaml
@@ -15,8 +15,8 @@ spec:
         name: shrink-test
     spec:
       containers:
-        - image: local.io/local/shrink-test:latest
-          imagePullPolicy: Never
+        - image: ghcr.io/jmcgrath207/k8s-ephemeral-storage-shrink-test:latest
+          imagePullPolicy: "{{ .Values.dev.image.imagePullPolicy }}"
           name: shrink-test
           resources:
             requests:
@@ -42,8 +42,8 @@ spec:
         name: grow-test
     spec:
       containers:
-        - image: local.io/local/grow-test:latest
-          imagePullPolicy: Never
+        - image: ghcr.io/jmcgrath207/k8s-ephemeral-storage-grow-test:latest
+          imagePullPolicy: "{{ .Values.dev.image.imagePullPolicy }}"
           name: grow-test
           resources:
             requests:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
-  tag: 1.4.0
+  tag: 1.4.1
   imagePullPolicy: IfNotPresent
 
 # -- Set metrics you want to enable
@@ -31,9 +31,11 @@ prometheus:
   release: kube-prometheus-stack
 
 
-# For local development and testing
+# -- For local development of kind and/or deploy grow and shrink test pods
 dev:
   enabled: false
+  image:
+    imagePullPolicy: IfNotPresent
 
 podAnnotations: {}
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,15 +29,16 @@ function main() {
   "deploy_type=Deployment",
   "log_level=debug"
   "dev.enabled=true",
+  "dev.image.imagePullPolicy=Never"
   "metrics.adjusted_polling_rate=true"
   )
 
   if [[ $ENV =~ "e2e"   ]]; then
-    docker build --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64 -f DockerfileTestGrow -t local.io/local/grow-test:latest .
-    kind load docker-image -v 9 --name "${DEPLOYMENT_NAME}-cluster" --nodes "${DEPLOYMENT_NAME}-cluster-worker" "local.io/local/grow-test:latest"
+    docker build --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64 -f DockerfileTestGrow -t ghcr.io/jmcgrath207/k8s-ephemeral-storage-grow-test:latest .
+    kind load docker-image -v 9 --name "${DEPLOYMENT_NAME}-cluster" --nodes "${DEPLOYMENT_NAME}-cluster-worker" "ghcr.io/jmcgrath207/k8s-ephemeral-storage-grow-test:latest"
 
-    docker build --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64 -f DockerfileTestShrink -t local.io/local/shrink-test:latest .
-    kind load docker-image -v 9 --name "${DEPLOYMENT_NAME}-cluster" --nodes "${DEPLOYMENT_NAME}-cluster-worker" "local.io/local/shrink-test:latest"
+    docker build --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64 -f DockerfileTestShrink -t ghcr.io/jmcgrath207/k8s-ephemeral-storage-shrink-test:latest .
+    kind load docker-image -v 9 --name "${DEPLOYMENT_NAME}-cluster" --nodes "${DEPLOYMENT_NAME}-cluster-worker" "ghcr.io/jmcgrath207/k8s-ephemeral-storage-shrink-test:latest"
 
     e2e_values_arr=("interval=5")
     common_set_values_arr+=("${e2e_values_arr[@]}")

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -19,3 +19,13 @@ docker build -f Dockerfile -t ghcr.io/jmcgrath207/$package:$VERSION .
 docker build -f Dockerfile -t ghcr.io/jmcgrath207/$package:latest .
 docker push ghcr.io/jmcgrath207/$package:$VERSION
 docker push ghcr.io/jmcgrath207/$package:latest
+
+docker build -f DockerfileTestGrow -t ghcr.io/jmcgrath207/k8s-ephemeral-storage-grow-test:latest .
+docker build -f DockerfileTestGrow -t ghcr.io/jmcgrath207/k8s-ephemeral-storage-grow-test:$VERSION .
+docker push ghcr.io/jmcgrath207/k8s-ephemeral-storage-grow-test:$VERSION
+docker push ghcr.io/jmcgrath207/k8s-ephemeral-storage-grow-test:latest
+
+docker build -f DockerfileTestGrow -t ghcr.io/jmcgrath207/k8s-ephemeral-storage-shrink-test:latest .
+docker build -f DockerfileTestGrow -t ghcr.io/jmcgrath207/k8s-ephemeral-storage-shrink-test:$VERSION .
+docker push ghcr.io/jmcgrath207/k8s-ephemeral-storage-shrink-test:$VERSION
+docker push ghcr.io/jmcgrath207/k8s-ephemeral-storage-shrink-test:latest


### PR DESCRIPTION
Made e2e testing images public. Only deployed when `dev.enabled=true`

https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkgs/container/k8s-ephemeral-storage-grow-test
https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkgs/container/k8s-ephemeral-storage-shrink-test
