### PR TITLE
Fix indentation

### DIFF
--- a/chart/templates/metrics.yaml
+++ b/chart/templates/metrics.yaml
@@ -11,14 +11,14 @@ spec:
       port: metrics
       scheme: http
       interval: "{{ .Values.interval }}s"
-      {{- if .Values.serviceMonitor.metricRelabelings }}
-        metricRelabelings:
-      {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
-      {{- end }}
-      {{- if .Values.serviceMonitor.relabelings }}
-        relabelings:
-      {{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
-      {{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 8 }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | indent 8 }}
+{{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
@@ -26,18 +26,18 @@ spec:
     matchLabels:
       {{- include "chart.selectorLabels" . | nindent 6 }}
   {{- if .Values.serviceMonitor.targetLabels }}
-    targetLabels:
-  {{- range .Values.serviceMonitor.targetLabels }}
-      - {{ . }}
-  {{- end }}
+  targetLabels:
+    {{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+    {{- end }}
   {{- end }}
   {{- if .Values.serviceMonitor.podTargetLabels }}
-    podTargetLabels:
-  {{- range .Values.serviceMonitor.podTargetLabels }}
-      - {{ . }}
+  podTargetLabels:
+    {{- range .Values.serviceMonitor.podTargetLabels }}
+    - {{ . }}
+    {{- end }}
   {{- end }}
-  {{- end }}
-
+  
 ---
 
 apiVersion: v1


### PR DESCRIPTION
Issue https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/issues/74

Fixed indentation which resolved helm error:

`Error: UPGRADE FAILED: YAML parse error on k8s-ephemeral-storage-metrics/templates/metrics.yaml: error converting YAML to JSON: yaml: line 16: did not find expected key`

Tested with values:

```
interval: 60
serviceMonitor:
  metricRelabelings:
    - sourceLabels: [pod_name]
      targetLabel: pod
    - sourceLabels: [pod_namespace]
      targetLabel: namespace
    # drop labels pod_.*
    - regex: "pod_(.*)"
      action: labeldrop
```

Deployed manifest spec:

```
spec:
  endpoints:
  - interval: 60s
    metricRelabelings:
    - action: replace
      sourceLabels:
      - pod_name
      targetLabel: pod
    - action: replace
      sourceLabels:
      - pod_namespace
      targetLabel: namespace
    - action: labeldrop
      regex: pod_(.*)
    path: /metrics
    port: metrics
    scheme: http
  namespaceSelector:
    matchNames:
    - kube-system
  selector:
    matchLabels:
      app.kubernetes.io/instance: k8s-ephemeral-storage-metrics
      app.kubernetes.io/name: k8s-ephemeral-storage-metrics
```