### PR TITLE
add additionalLabels to ServiceMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | serviceMonitor.podTargetLabels | list | `[]` |  |
 | serviceMonitor.relabelings | list | `[]` |  |
 | serviceMonitor.targetLabels | list | `[]` |  |
+| serviceMonitor.additionalLabels | object | `{}` |  |
 | tolerations | list | `[]` |  |
 
 ## Contribute

--- a/chart/README.md
+++ b/chart/README.md
@@ -36,6 +36,7 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | serviceMonitor.podTargetLabels | list | `[]` |  |
 | serviceMonitor.relabelings | list | `[]` |  |
 | serviceMonitor.targetLabels | list | `[]` |  |
+| serviceMonitor.additionalLabels | object | `{}` |  |
 | tolerations | list | `[]` |  |
 
 ## Contribute

--- a/chart/templates/metrics.yaml
+++ b/chart/templates/metrics.yaml
@@ -5,6 +5,9 @@ metadata:
   name: k8s-ephemeral-storage-metrics
   labels:
   {{- include "chart.labels" . | nindent 4 }}
+{{- with .Values.serviceMonitor.additionalLabels }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   endpoints:
     - path: /metrics

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,7 @@ serviceMonitor:
    targetLabels: []
    # Set podTargetLabels as per https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitorSpec
    podTargetLabels: []
+   additionalLabels: {}
 
 
 # -- Set metrics you want to enable


### PR DESCRIPTION
Add additionalLabels to ServiceMonitor

Useful for when prometheus is configure with a serviceMonitorSelector