### PR TITLE
add ephemeral_storage_container_volume_usage  metrics

### DIFF
--- a/pkg/pod/factory.go
+++ b/pkg/pod/factory.go
@@ -12,6 +12,7 @@ var (
 )
 
 type Collector struct {
+	containerVolumeUsage            bool
 	containerLimitsPercentage       bool
 	containerVolumeLimitsPercentage bool
 	lookup                          *map[string]pod
@@ -23,11 +24,13 @@ type Collector struct {
 
 func NewCollector(sampleInterval int64) Collector {
 	podUsage, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_POD_USAGE", "false"))
+	containerVolumeUsage, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_CONTAINER_VOLUME_USAGE", "false"))
 	containerLimitsPercentage, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_CONTAINER_LIMIT_PERCENTAGE", "false"))
 	containerVolumeLimitsPercentage, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_CONTAINER_VOLUME_LIMITS_PERCENTAGE", "false"))
 	lookup := make(map[string]pod)
 
 	var c = Collector{
+		containerVolumeUsage:            containerVolumeUsage,
 		containerLimitsPercentage:       containerLimitsPercentage,
 		containerVolumeLimitsPercentage: containerVolumeLimitsPercentage,
 		lookup:                          &lookup,

--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -108,23 +108,23 @@ func (cr Collector) getContainerData(c v1.Container, p v1.Pod) container {
 	setContainer.name = c.Name
 	matchKey := v1.ResourceName("ephemeral-storage")
 
-	if cr.containerVolumeLimitsPercentage && p.Spec.Volumes != nil {
+	if cr.containerVolumeUsage && cr.containerVolumeLimitsPercentage && p.Spec.Volumes != nil {
 		collectMounts := false
 
 		podMountsMap := make(map[string]float64)
 		for _, v := range p.Spec.Volumes {
 			if v.VolumeSource.EmptyDir != nil {
+				podMountsMap[v.Name] = 0
+				collectMounts = true
 				if v.VolumeSource.EmptyDir.SizeLimit != nil {
 					podMountsMap[v.Name] = v.VolumeSource.EmptyDir.SizeLimit.AsApproximateFloat64()
 					collectMounts = true
 				}
 			}
-
 		}
 
 		if collectMounts {
 			var collectVolumes []emptyDirVolumes
-
 			for _, volumeMount := range c.VolumeMounts {
 				size, ok := podMountsMap[volumeMount.Name]
 				if ok {

--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -108,7 +108,7 @@ func (cr Collector) getContainerData(c v1.Container, p v1.Pod) container {
 	setContainer.name = c.Name
 	matchKey := v1.ResourceName("ephemeral-storage")
 
-	if cr.containerVolumeUsage && cr.containerVolumeLimitsPercentage && p.Spec.Volumes != nil {
+	if (cr.containerVolumeUsage || cr.containerVolumeLimitsPercentage) && p.Spec.Volumes != nil {
 		collectMounts := false
 
 		podMountsMap := make(map[string]float64)


### PR DESCRIPTION
add `ephemeral_storage_container_volume_usage` 

the sample output 

```
ephemeral_storage_container_volume_usage{cluster="development-k8s-cluster",container="k8s-ephemeral-storage",endpoint="metrics",exported_container="postgresql",instance="172.18.23.200:9100",job="prometheus-ephemeral-storage-exporter",mount_path="/dev/shm",namespace="monitor-system",node_name="10-9-9-46.vm",pod="prometheus-ephemeral-storage-exporter-86dcfd97d9-wd79f",pod_name="postgresql-0",pod_namespace="demo-postgresql",prometheus="monitor-system/victoria-metrics-cluster",service="prometheus-ephemeral-storage-exporter",volume_name="dshm"} 210,870,272
```