### PR TITLE
Add/expose metrics only specific ns

### DIFF
--- a/.github/workflows/eph-storage-workflow.yaml
+++ b/.github/workflows/eph-storage-workflow.yaml
@@ -1,0 +1,58 @@
+---
+name: eph-storage-workflow
+on:
+  push:
+    branches: [ add/expose-metrics-only-specific-ns ]
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout 5m
+
+  docker:
+    name: docker
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - uses: docker/build-push-action@v2
+        with:
+          file: "Dockerfile"
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -78,6 +78,10 @@ spec:
               value: "{{ .Values.max_node_concurrency }}"
             - name: LOG_LEVEL
               value: "{{ .Values.log_level }}"
+              {{- if .Values.labelSelector }}
+            - name: EPHEMERAL_STORAGE_LABEL
+              value: "{{ .Values.labelSelector }}"
+              {{- end }}
               {{- if .Values.metrics.ephemeral_storage_pod_usage }}
             - name: EPHEMERAL_STORAGE_POD_USAGE
               value: "{{ .Values.metrics.ephemeral_storage_pod_usage }}"

--- a/chart/templates/RBAC.yaml
+++ b/chart/templates/RBAC.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- include "chart.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["nodes","nodes/proxy", "nodes/stats", "pods"]
+    resources: ["nodes","nodes/proxy", "nodes/stats", "pods", "namespaces"]
     verbs: ["get","list", "watch"]
 
 ---

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-  "os"
 	"context"
 	"encoding/json"
 	"flag"
@@ -17,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 )
@@ -26,7 +26,7 @@ var (
 	sampleIntervalMill int64
 	Node               node.Node
 	Pod                pod.Collector
-	clientset *kubernetes.Clientset
+	clientset          *kubernetes.Clientset
 )
 
 func getMonitoredNamespaces(clientset *kubernetes.Clientset) ([]string, error) {
@@ -103,7 +103,6 @@ func setMetrics(clientset *kubernetes.Clientset, nodeName string, monitoredNames
 			continue
 		}
 
-
 		if !monitoredNamespaces[podNamespace] {
 			log.Debug().Msg(fmt.Sprintf("Skipping pod %s/%s as it does not meet label requirements", podName, podNamespace))
 			continue
@@ -113,7 +112,8 @@ func setMetrics(clientset *kubernetes.Clientset, nodeName string, monitoredNames
 		Pod.SetMetrics(podName, podNamespace, nodeName, usedBytes, availableBytes, capacityBytes, p.Volumes)
 	}
 
-	adjustTime := sampleIntervalMill - time.Now().Sub(start).Milliseconds()
+	//adjustTime := sampleIntervalMill - time.Now().Sub(start).Milliseconds()
+	adjustTime := sampleIntervalMill - time.Since(start).Milliseconds()
 	if adjustTime <= 0.0 {
 		log.Error().Msgf("Node %s: Polling Rate could not keep up. Adjust your Interval to a higher number than %d seconds", nodeName, sampleInterval)
 	}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+  "os"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -11,6 +13,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"net/http"
 	"strconv"
 	"time"
@@ -21,7 +26,29 @@ var (
 	sampleIntervalMill int64
 	Node               node.Node
 	Pod                pod.Collector
+	clientset *kubernetes.Clientset
 )
+
+func getMonitoredNamespaces(clientset *kubernetes.Clientset) ([]string, error) {
+	labelSelector := os.Getenv("EPHEMERAL_STORAGE_LABEL")
+
+	if labelSelector == "" {
+		labelSelector = "ephemeral-storage-monitoring=enabled"
+	}
+
+	namespaceList, err := clientset.CoreV1().Namespaces().List(context.TODO(), v1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var namespaces []string
+	for _, ns := range namespaceList.Items {
+		namespaces = append(namespaces, ns.Name)
+	}
+	return namespaces, nil
+}
 
 type ephemeralStorageMetrics struct {
 	Node struct {
@@ -42,7 +69,11 @@ type ephemeralStorageMetrics struct {
 	}
 }
 
-func setMetrics(nodeName string) {
+func setMetrics(clientset *kubernetes.Clientset, nodeName string, monitoredNamespaces map[string]bool) {
+	if clientset == nil {
+		log.Error().Msg("Kubernetes clientset is nil")
+		return
+	}
 
 	var data ephemeralStorageMetrics
 
@@ -55,7 +86,11 @@ func setMetrics(nodeName string) {
 	}
 
 	log.Debug().Msg(fmt.Sprintf("Fetched proxy stats from node : %s", nodeName))
-	_ = json.Unmarshal(content, &data)
+	err = json.Unmarshal(content, &data)
+	if err != nil {
+		log.Error().Msgf("Failed to unmarshal content: %v", err)
+		return
+	}
 
 	for _, p := range data.Pods {
 		podName := p.PodRef.Name
@@ -67,6 +102,13 @@ func setMetrics(nodeName string) {
 			log.Warn().Msg(fmt.Sprintf("pod %s/%s on %s has no metrics on its ephemeral storage usage", podName, podNamespace, nodeName))
 			continue
 		}
+
+
+		if !monitoredNamespaces[podNamespace] {
+			log.Debug().Msg(fmt.Sprintf("Skipping pod %s/%s as it does not meet label requirements", podName, podNamespace))
+			continue
+		}
+
 		Node.SetMetrics(nodeName, availableBytes, capacityBytes)
 		Pod.SetMetrics(podName, podNamespace, nodeName, usedBytes, availableBytes, capacityBytes, p.Volumes)
 	}
@@ -81,13 +123,23 @@ func setMetrics(nodeName string) {
 
 }
 
-func getMetrics() {
+func getMetrics(clientset *kubernetes.Clientset) {
 
 	Node.WaitGroup.Wait()
 	Pod.WaitGroup.Wait()
 
 	p, _ := ants.NewPoolWithFunc(Node.MaxNodeQueryConcurrency, func(node interface{}) {
-		setMetrics(node.(string))
+		monitoredNamespacesList, err := getMonitoredNamespaces(clientset)
+		if err != nil {
+			log.Error().Msgf("Failed to fetch monitored namespaces: %v", err)
+			return
+		}
+
+		monitoredNamespaces := make(map[string]bool)
+		for _, ns := range monitoredNamespacesList {
+			monitoredNamespaces[ns] = true
+		}
+		setMetrics(clientset, node.(string), monitoredNamespaces)
 	}, ants.WithExpiryDuration(time.Duration(sampleInterval)*time.Second))
 
 	defer p.Release()
@@ -107,7 +159,6 @@ func main() {
 	flag.Parse()
 	port := dev.GetEnv("METRICS_PORT", "9100")
 
-	// Shared Vars
 	pprofEnabled, _ := strconv.ParseBool(dev.GetEnv("PPROF", "false"))
 	sampleInterval, _ = strconv.ParseInt(dev.GetEnv("SCRAPE_INTERVAL", "15"), 10, 64)
 	sampleIntervalMill = sampleInterval * 1000
@@ -117,15 +168,62 @@ func main() {
 	Node = node.NewCollector(sampleInterval)
 	Pod = pod.NewCollector(sampleInterval)
 
+	var err error
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Error().Msgf("Failed to create in-cluster config: %v", err)
+		return
+	}
+
+	config.QPS = 20.0
+	config.Burst = 40
+	clientset, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Error().Msgf("Failed to create Kubernetes clientset: %v", err)
+		return
+	}
+
 	if pprofEnabled {
 		go dev.EnablePprof()
 	}
 	go Node.Get()
 	go Node.Watch()
-	go getMetrics()
+
+	go func() {
+		Node.WaitGroup.Wait()
+		Pod.WaitGroup.Wait()
+
+		p, _ := ants.NewPoolWithFunc(Node.MaxNodeQueryConcurrency, func(node interface{}) {
+			monitoredNamespacesList, err := getMonitoredNamespaces(clientset)
+			if err != nil {
+				log.Error().Msgf("Failed to fetch monitored namespaces: %v", err)
+				return
+			}
+			monitoredNamespaces := make(map[string]bool)
+			for _, ns := range monitoredNamespacesList {
+				monitoredNamespaces[ns] = true
+			}
+			setMetrics(clientset, node.(string), monitoredNamespaces)
+		}, ants.WithExpiryDuration(time.Duration(sampleInterval)*time.Second))
+
+		defer p.Release()
+
+		for {
+			nodeSlice := Node.Set.ToSlice()
+
+			for _, node := range nodeSlice {
+				_ = p.Invoke(node)
+			}
+
+			time.Sleep(time.Duration(sampleInterval) * time.Second)
+		}
+	}()
+
+	go getMetrics(clientset)
+
 	http.Handle("/metrics", promhttp.Handler())
 	log.Info().Msg(fmt.Sprintf("Starting server listening on :%s", port))
-	err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+	err = http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
 	if err != nil {
 		log.Error().Msg(fmt.Sprintf("Listener Failed : %s\n", err.Error()))
 		panic(err.Error())

--- a/pkg/node/k8s.go
+++ b/pkg/node/k8s.go
@@ -139,12 +139,28 @@ func (n *Node) Watch() {
 	// Start the informer to begin watching for Node events
 	go sharedInformerFactory.Start(stopCh)
 
+	// Use a ticker for periodic actions
+	ticker := time.NewTicker(time.Duration(n.sampleInterval) * time.Second)
+	defer ticker.Stop()
+
 	for {
-		time.Sleep(time.Duration(n.sampleInterval) * time.Second)
 		select {
+		case <-ticker.C:
+			// Perform periodic tasks here, if any
+
 		case <-stopCh:
 			log.Error().Msg("Watcher NodeWatch stopped.")
 			os.Exit(1)
 		}
 	}
+	/*
+		for {
+			time.Sleep(time.Duration(n.sampleInterval) * time.Second)
+			select {
+			case <-stopCh:
+				log.Error().Msg("Watcher NodeWatch stopped.")
+				os.Exit(1)
+			}
+		}
+	*/
 }

--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -90,15 +90,28 @@ func (cr Collector) podWatch() {
 	// Start the informer to begin watching for Pod events
 	go sharedInformerFactory.Start(stopCh)
 
+	ticker := time.NewTicker(time.Duration(cr.sampleInterval) * time.Second)
+	defer ticker.Stop()
+
 	for {
-		time.Sleep(time.Duration(cr.sampleInterval) * time.Second)
 		select {
+		case <-ticker.C:
+			// Periodic task placeholder (if any)
 		case <-stopCh:
 			log.Error().Msg("Watcher podWatch stopped.")
 			os.Exit(1)
 		}
 	}
-
+	/*
+		for {
+			time.Sleep(time.Duration(cr.sampleInterval) * time.Second)
+			select {
+			case <-stopCh:
+				log.Error().Msg("Watcher podWatch stopped.")
+				os.Exit(1)
+			}
+		}
+	*/
 }
 
 // Collector for container data


### PR DESCRIPTION
This pull request introduces changes to to enable the exporter to expose metrics only for ns labeled with specific label. Introduced a new env var `EPHEMERAL_STORAGE_LABEL` to specify the label selector for ns to monitor. 

- `getMonitoredNamespaces(clientset *kubernetes.Clientset) ([]string, error)` now reads the label selector from the `EPHEMERAL_STORAGE_LABEL` env var.
- `setMetrics(clientset *kubernetes.Clientset, nodeName string, monitoredNamespaces map[string]bool)` now receives a map of monitored ns to check if a pod’s ns is in the monitored list.