### PR TITLE
set percentage node used instead of available

### DIFF
--- a/pkg/node/metrics.go
+++ b/pkg/node/metrics.go
@@ -2,6 +2,8 @@ package node
 
 import (
 	"fmt"
+	"math"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 )
@@ -79,7 +81,10 @@ func (n *Node) SetMetrics(nodeName string, availableBytes float64, capacityBytes
 	}
 
 	if n.nodePercentage {
-		setValue := (availableBytes / capacityBytes) * 100.0
+		setValue := math.NaN()
+		if capacityBytes > 0. {
+			setValue = math.Max(capacityBytes-availableBytes, 0.) * 100.0 / capacityBytes
+		}
 		nodePercentageGaugeVec.With(prometheus.Labels{"node_name": nodeName}).Set(setValue)
 		log.Debug().Msg(fmt.Sprintf("Node: %s percentage used: %f", nodeName, setValue))
 	}

--- a/pkg/pod/metrics.go
+++ b/pkg/pod/metrics.go
@@ -2,6 +2,8 @@ package pod
 
 import (
 	"fmt"
+	"math"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
@@ -166,9 +168,11 @@ func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName str
 				if c.limit != 0 {
 					// Use Limit from Container
 					setValue = (usedBytes / c.limit) * 100.0
+				} else if capacityBytes > 0. {
+					// Default to Node Used Ephemeral Storage
+					setValue = math.Max(capacityBytes-availableBytes, 0.) * 100.0 / capacityBytes
 				} else {
-					// Default to Node Available Ephemeral Storage
-					setValue = (availableBytes / capacityBytes) * 100.0
+					setValue = math.NaN()
 				}
 				containerPercentageLimitsVec.With(labels).Set(setValue)
 			}


### PR DESCRIPTION
First of all, thanks for this exporter. We find it very useful.

While implementing alerting rules based on the metrics provided, I found out an inconsistency between the metric's description `Percentage of ephemeral storage used on a node` and the actual value returned, which is `Percentage of ephemeral storage available on a node`. Either the description or the calculation is wrong.

This PR attempts to fix the latter because it makes both `ephemeral_storage_{node,container_limit}_percentage` metrics consistent with `setValue = (usedBytes / c.limit) * 100.0` (the value calculated for container if its limit is set).

What do you think?