### PR TITLE
added source label to ephemeral_storage_container_limit_percentage

### DIFF
--- a/pkg/pod/metrics.go
+++ b/pkg/pod/metrics.go
@@ -76,6 +76,8 @@ func (cr Collector) createMetrics() {
 			"node_name",
 			// Name of container
 			"container",
+			// Source of the limit (either "container" for pod.spec.containers.resources.limits or "node")
+			"source",
 		},
 	)
 
@@ -164,10 +166,11 @@ func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName str
 		if okPodResult {
 			for _, c := range podResult.containers {
 				labels := prometheus.Labels{"pod_namespace": podNamespace,
-					"pod_name": podName, "node_name": nodeName, "container": c.name}
+					"pod_name": podName, "node_name": nodeName, "container": c.name, "source": "node"}
 				if c.limit != 0 {
 					// Use Limit from Container
 					setValue = (usedBytes / c.limit) * 100.0
+					labels["source"] = "container"
 				} else if capacityBytes > 0. {
 					// Default to Node Used Ephemeral Storage
 					setValue = math.Max(capacityBytes-availableBytes, 0.) * 100.0 / capacityBytes

--- a/tests/e2e/deployment_test.go
+++ b/tests/e2e/deployment_test.go
@@ -2,8 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"io"
 	"net/http"
 	"os/exec"
@@ -12,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var httpClient *http.Client
@@ -120,9 +121,10 @@ func checkPrometheus(checkSlice []string, inverse bool) {
 
 func WatchContainerPercentage() {
 	status := 0
-	re := regexp.MustCompile(`ephemeral_storage_container_limit_percentage{container="grow-test",node_name="minikube".+,pod_namespace="ephemeral-metrics"}\s+(.+)`)
+	re := regexp.MustCompile(`ephemeral_storage_container_limit_percentage{container="grow-test",node_name="minikube".+,pod_namespace="ephemeral-metrics",source="container"}\s+(.+)`)
 	output := requestPrometheusString()
 	match := re.FindAllStringSubmatch(output, -1)
+	gomega.Expect(match).ShouldNot(gomega.BeEmpty())
 	floatValue, _ := strconv.ParseFloat(match[0][1], 64)
 	if floatValue < 100.0 {
 		status = 1


### PR DESCRIPTION
in order to differentiate between "hard" and "soft" limits

"hard" comes `pod.spec.containers.resources.limits["ephemeral-storage"]` (if set) and terminates the pod once reached

"soft" comes from the node and may not necessarily cause an eviction of the pod in question

#### Motivation

To implement an alert rule [à la KubePersistentVolumeFillingUp](https://github.com/prometheus-operator/kube-prometheus/blob/b5b59bc0b45508b85647eb7a84b96dc167be15f1/manifests/kubernetesControlPlane-prometheusRule.yaml#L363) for a container like this:

```yaml
        - alert: ContainerEphemeralStorageUsageAtLimit
          annotations:
            description: >-
              {{ `Ephemeral storage usage of pod/container {{ $labels.pod_name
              }}/{{ $labels.exported_container }} in Namespace {{
              $labels.pod_namespace }} on Node {{ $labels.node_name }} {{ with
              $labels.cluster -}} on Cluster {{ . }} {{- end }} is at {{ $value
              }}% of the limit.` }}
            summary: Container ephemeral storage usage is at the limit.
          expr: |-2
            ( ( max by (node_name, pod_namespace, pod_name, exported_container)
                       (avg_over_time(ephemeral_storage_container_limit_percentage[5m]))
              > 85.0)
            # ignore soft-limits (containers without an ephemeral-storage limit set
            # will report ephemeral_storage_node_percentage as their limit)
            and on (pod_namespace, pod_name, exported_container)
                   ( max_over_time(
                     ( abs(ephemeral_storage_container_limit_percentage
                     - on (node_name) group_left () ephemeral_storage_node_percentage))[5m:30s])
                   # there can be a slight deviation between the metric
                   # reported for a container and the node
                   > 0.06)
            )
            # ignore pods that haven't been running for some time (e.g. completed jobs)
            unless on (pod_namespace, pod_name)
                      ( (label_replace(label_replace(
                           sum by (namespace, pod)
                                  (max_over_time(kube_pod_status_phase{phase="Running"}[1m])),
                           "pod_namespace", "$1", "namespace", "(.*)"),
                           "pod_name", "$1", "pod", "(.*)"))
                      == 0)
          for: 1m
          labels:
            severity: warning
```

Notice the middle part of the expression (`and on (pod_namespace, pod_name, exported_container) ( max_over_time( ... > 0.06)` which makes the whole evaluation fragile, complicated and slow.

It is needed to filter out all containers with `pod.spec.containers.requests.limits["ephemeral-storage"]` **un**set.

Without it, there would be too many instances of the alert generated for a single node running out of ephemeral storage (one for each container running on the node). For that case, there should be another alert like `NodeOutOfEphemeralStorage`

With this change in place, one could simplify the expression to:

```
            ( max by (node_name, pod_namespace, pod_name, exported_container)
                       (avg_over_time(ephemeral_storage_container_limit_percentage{source="container"}[5m]))
            > 85.0)
            # ignore pods that haven't been running for some time (e.g. completed jobs)
            unless on (pod_namespace, pod_name)
                      ( (label_replace(label_replace(
                           sum by (namespace, pod)
                                  (max_over_time(kube_pod_status_phase{phase="Running"}[1m])),
                           "pod_namespace", "$1", "namespace", "(.*)"),
                           "pod_name", "$1", "pod", "(.*)"))
                      == 0)
```

I don't have a strong opinion on the new label name/ values. Instead of adding a new label, there could be a whole new metric instead (e.g. `ephemeral_storage_container_hard_limit_percentage`).

Please let me know what you think.