### PR TITLE
fix: use Mebibytes when scraping values from pod manifest

### DIFF
--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -141,6 +141,7 @@ func (cr Collector) getContainerData(c v1.Container, p v1.Pod) container {
 		for key, val := range c.Resources.Limits {
 			if key == matchKey {
 				setContainer.limit = val.AsApproximateFloat64()
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Cast used megabyte to Mebibytes when calculating the container limit and container limit volume size since this is scraped from the Kubernetes pod manifest.

