### PR TITLE
chart: Make min prediction usage configurable

### DIFF
--- a/chart/templates/prometheusrules.yaml
+++ b/chart/templates/prometheusrules.yaml
@@ -50,7 +50,7 @@ spec:
           expr: |-2
             (   ( max by (node_name, pod_namespace, pod_name, exported_container)
                          (ephemeral_storage_container_limit_percentage{source="container"})
-                > 33.3)
+                > {{ $rules.predictMinCurrentUsage | float64 }})
             and on (pod_namespace, pod_name, exported_container)
                    ( predict_linear( ephemeral_storage_container_limit_percentage{source="container"}[2h]
                                    , {{ $predictFilledHours | float64 }}*3600)
@@ -103,7 +103,7 @@ spec:
           expr: |-2
             (   ( max by (pod_namespace, pod_name, volume_name)
                          (ephemeral_storage_container_volume_limit_percentage)
-                > 33.3)
+                > {{ $rules.predictMinCurrentUsage | float64 }})
             and ( max by (pod_namespace, pod_name, volume_name)
                          (predict_linear( ephemeral_storage_container_volume_limit_percentage[2h]
                                         , {{ $predictFilledHours | float64 }}*3600))

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -63,6 +63,8 @@ prometheus:
     enable: false
     # -- How many hours in the future to predict filling up of a volume
     predictFilledHours: 12
+    # -- What percentage of limit must be used right now to predict filling up of a volume
+    predictMinCurrentUsage: 33.3
     # -- What additional labels to set on alerts
     labels:
       severity: warning


### PR DESCRIPTION
This makes the threshold of *current* usage that is needed to trigger a prediction alert configurable.