### PR TITLE
feat(chart): add additional labels for Deployment/DaemonSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | containerSecurityContext.runAsNonRoot | bool | `true` |  |
 | deploy_type | string | `"Deployment"` | Set as Deployment for single controller to query all nodes or Daemonset |
+| deploy_labels | object | `{}` | Set additional labels for the Deployment/Daemonset |
 | dev | object | `{"enabled":false,"grow":{"image":"ghcr.io/jmcgrath207/k8s-ephemeral-storage-grow-test:latest","imagePullPolicy":"IfNotPresent"},"shrink":{"image":"ghcr.io/jmcgrath207/k8s-ephemeral-storage-shrink-test:latest","imagePullPolicy":"IfNotPresent"}}` | For local development or testing that will deploy grow and shrink pods and debug service |
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.imagePullSecrets | list | `[]` |  |

--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "chart.labels" . | nindent 4 }}
+  {{- if .Values.deploy_labels }}
+  {{- toYaml .Values.deploy_labels | nindent 4 }}
+  {{- end }}
 spec:
   {{- if eq .Values.deploy_type "Deployment" }}
   replicas: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -50,6 +50,8 @@ metrics:
 log_level: info
 # -- Set as Deployment for single controller to query all nodes or Daemonset
 deploy_type: Deployment
+# -- Set additional labels for the Deployment/Daemonset
+deploy_labels: {}
 # Note in testing, Kube API does not refresh faster than 10 seconds
 # -- Polling node rate for exporter
 interval: 15 # Seconds


### PR DESCRIPTION
This PR adds a Helm value `deploy_labels` that can be used to add labels to the Deployment/DaemonSet.