### PR TITLE
Update util.go

### DIFF
--- a/pkg/dev/util.go
+++ b/pkg/dev/util.go
@@ -65,6 +65,15 @@ func SetK8sClient() {
 		setScrapeFromKubelet(config)
 	}
 
+	// fix: reading ops and burst from os env.
+	if qps, err := strconv.ParseFloat(GetEnv("CLIENT_GO_QPS", "5"), 32); err == nil {
+		config.QPS = float32(qps)
+	}
+	if burst, err := strconv.Atoi(GetEnv("CLIENT_GO_BURST", "10")); err == nil {
+		config.Burst = burst
+	}
+
+
 	// creates the clientset
 	Clientset, err = kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
Loading envs(CLIENT_GO_QPS and CLIENT_GO_BURST).

In a cluster of thousands of K8S nodes, a lot of work has been done to optimize the QPS of the APIServer. However, this prompt is client-side current limiting, which is not what should happen, although it is not a serious disaster. We should support configurable client QPS instead of fixed default values.

When the special value configured by the DevOps personnel cannot be obtained in the environment variable, the default behavior is adopted.