### PR TITLE
feat(chart): add configurable probe settings to replace hardcoded values

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | pod_labels | object | `{}` | Set additional labels for the Pods |
 | pprof | bool | `false` | Enable Pprof |
 | priorityClassName | string | `nil` |  |
+| probes | object | `{"liveness":{"failureThreshold":10,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":30},"readiness":{"failureThreshold":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}}` | Liveness and Readiness probe configuration |
+| probes.liveness | object | `{"failureThreshold":10,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":30}` | Liveness probe configuration |
+| probes.liveness.failureThreshold | int | `10` | Number of consecutive failures required to consider the container as not ready |
+| probes.liveness.initialDelaySeconds | int | `10` | Delay before the first probe is initiated |
+| probes.liveness.periodSeconds | int | `10` | How often to perform the probe |
+| probes.liveness.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
+| probes.liveness.timeoutSeconds | int | `30` | Number of seconds after which the probe times out |
+| probes.readiness | object | `{"failureThreshold":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe configuration |
+| probes.readiness.failureThreshold | int | `10` | Number of consecutive failures required to consider the container as not ready |
+| probes.readiness.periodSeconds | int | `10` | How often to perform the probe |
+| probes.readiness.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
+| probes.readiness.timeoutSeconds | int | `1` | Number of seconds after which the probe times out |
 | prometheus.additionalLabels | object | `{}` | Add labels to the PrometheusRule.Spec |
 | prometheus.enable | bool | `true` |  |
 | prometheus.release | string | `"kube-prometheus-stack"` |  |

--- a/chart/README.md
+++ b/chart/README.md
@@ -50,6 +50,18 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | pod_labels | object | `{}` | Set additional labels for the Pods |
 | pprof | bool | `false` | Enable Pprof |
 | priorityClassName | string | `nil` |  |
+| probes | object | `{"liveness":{"failureThreshold":10,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":30},"readiness":{"failureThreshold":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}}` | Liveness and Readiness probe configuration |
+| probes.liveness | object | `{"failureThreshold":10,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":30}` | Liveness probe configuration |
+| probes.liveness.failureThreshold | int | `10` | Number of consecutive failures required to consider the container as not ready |
+| probes.liveness.initialDelaySeconds | int | `10` | Delay before the first probe is initiated |
+| probes.liveness.periodSeconds | int | `10` | How often to perform the probe |
+| probes.liveness.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
+| probes.liveness.timeoutSeconds | int | `30` | Number of seconds after which the probe times out |
+| probes.readiness | object | `{"failureThreshold":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe configuration |
+| probes.readiness.failureThreshold | int | `10` | Number of consecutive failures required to consider the container as not ready |
+| probes.readiness.periodSeconds | int | `10` | How often to perform the probe |
+| probes.readiness.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
+| probes.readiness.timeoutSeconds | int | `1` | Number of seconds after which the probe times out |
 | prometheus.additionalLabels | object | `{}` | Add labels to the PrometheusRule.Spec |
 | prometheus.enable | bool | `true` |  |
 | prometheus.release | string | `"kube-prometheus-stack"` |  |

--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -69,24 +69,24 @@ spec:
               protocol: TCP
               {{ end }}
           livenessProbe:
-            failureThreshold: 10
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             httpGet:
               path: /metrics
               port: {{ .Values.metrics.port  }}
               scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 30
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            successThreshold: {{ .Values.probes.liveness.successThreshold }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
           readinessProbe:
-            failureThreshold: 10
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
             httpGet:
               path: /metrics
               port: {{ .Values.metrics.port  }}
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            successThreshold: {{ .Values.probes.readiness.successThreshold }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -142,3 +142,28 @@ containerSecurityContext:
   privileged: false
   readOnlyRootFilesystem: false
   runAsNonRoot: true
+
+# -- Liveness and Readiness probe configuration
+probes:
+  # -- Liveness probe configuration
+  liveness:
+    # -- Number of consecutive failures required to consider the container as not ready
+    failureThreshold: 10
+    # -- Delay before the first probe is initiated
+    initialDelaySeconds: 10
+    # -- How often to perform the probe
+    periodSeconds: 10
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # -- Number of seconds after which the probe times out
+    timeoutSeconds: 30
+  # -- Readiness probe configuration
+  readiness:
+    # -- Number of consecutive failures required to consider the container as not ready
+    failureThreshold: 10
+    # -- How often to perform the probe
+    periodSeconds: 10
+    # -- Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # -- Number of seconds after which the probe times out
+    timeoutSeconds: 1


### PR DESCRIPTION
Fixes #166

This PR makes probe settings configurable by:
- Adding comprehensive probe configuration to values.yaml
- Replacing hardcoded values in DeployType.yaml with template variables
- Maintaining backward compatibility with existing defaults
- Including all probe parameters (timeouts, thresholds, periods, delays)

The hardcoded `timeoutSeconds: 1` for readiness probes can now be configured based on deployment requirements.