### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: e2e
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/security/code-scanning/1](https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/security/code-scanning/1)

To fix the problem, explicitly define `permissions` for the workflow or the specific job so that the `GITHUB_TOKEN` has only the scopes it needs. Since nothing in the shown job clearly requires write access or special scopes, the safest minimal configuration is `contents: read` at the workflow or job level.

The best fix without changing existing functionality is to add a `permissions` block at the root (top-level) of `.github/workflows/test.yaml`, right after the `name: e2e` line and before `on:`. This will apply to all jobs in the workflow (currently just `e2e`). We’ll set:

```yaml
permissions:
  contents: read
```

No additional imports or methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
