### PR TITLE
chore: add nameOverride and fullnameOverride values

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-ephemeral-storage-metrics
-version: 1.19.2
+version: 1.20.0
 appVersion: 1.19.2
 kubeVersion: ">=1.21.0-0"
 description: Ephemeral storage metrics for prometheus operator.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-ephemeral-storage-metrics
-version: 1.20.0
+version: 1.19.2
 appVersion: 1.19.2
 kubeVersion: ">=1.21.0-0"
 description: Ephemeral storage metrics for prometheus operator.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,3 +1,8 @@
+# -- Override the name of the chart
+nameOverride: ""
+# -- Override the full name of the chart
+fullnameOverride: ""
+
 image:
   repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
   tag: 1.19.2


### PR DESCRIPTION
## Summary
- Add `nameOverride` and `fullnameOverride` values to the Helm chart
- The `_helpers.tpl` template already supports these values but they were not exposed in `values.yaml`
- Bump chart version from 1.19.2 to 1.20.0

## Motivation
Users need to override deployment names when deploying multiple instances or integrating with existing naming conventions (e.g. deploying as a sub-chart in an umbrella chart). Without these values exposed in `values.yaml`, customizing resource names was not possible through standard Helm value overrides.

## Changes
- `chart/values.yaml`: Added `nameOverride` and `fullnameOverride` with empty string defaults
- `chart/Chart.yaml`: Bumped version to 1.20.0

Signed-off-by: Yuan Chen <yuanchen97@gmail.com>