### PR TITLE
Add more metrics for containers ephemeral storage (rootfs and logs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ chart/k8s-ephemeral-storage-metrics-*.tgz
 .vscode/
 /bin/
 .idea
+/tests/charts/observability/Chart.lock
+/tests/charts/observability/charts/

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ chart/k8s-ephemeral-storage-metrics-*.tgz
 
 # vscode
 .vscode/
+/bin/
+.idea

--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | kubelet | object | `{"insecure":false,"readOnlyPort":0,"scrape":false}` | Scrape metrics through kubelet instead of kube api |
 | log_level | string | `"info"` |  |
 | max_node_concurrency | int | `10` | Max number of concurrent query requests to the kubernetes API. |
-| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_container_volume_limit_percentage":true,"ephemeral_storage_container_volume_usage":true,"ephemeral_storage_inodes":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true,"gc_batch_size":500,"gc_enabled":false,"gc_interval":5,"port":9100}` | Set metrics you want to enable |
+| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_container_logs_usage":true,"ephemeral_storage_container_rootfs_usage":true,"ephemeral_storage_container_volume_limit_percentage":true,"ephemeral_storage_container_volume_usage":true,"ephemeral_storage_inodes":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true,"gc_batch_size":500,"gc_enabled":false,"gc_interval":5,"port":9100}` | Set metrics you want to enable |
 | metrics.adjusted_polling_rate | bool | `false` | Create the ephemeral_storage_adjusted_polling_rate metrics to report Adjusted Poll Rate in milliseconds. Typically used for testing. |
 | metrics.ephemeral_storage_container_limit_percentage | bool | `true` | Percentage of ephemeral storage used by a container in a pod |
+| metrics.ephemeral_storage_container_logs_usage | bool | `true` | Current logs bytes used/available/capacity for a container in a pod |
+| metrics.ephemeral_storage_container_rootfs_usage | bool | `true` | Current rootfs bytes used/available/capacity for a container in a pod |
 | metrics.ephemeral_storage_container_volume_limit_percentage | bool | `true` | Percentage of ephemeral storage used by a container's volume in a pod |
 | metrics.ephemeral_storage_container_volume_usage | bool | `true` | Current ephemeral storage used by a container's volume in a pod |
 | metrics.ephemeral_storage_inodes | bool | `true` | Current ephemeral inode usage of pod |

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | list_pods_with_cache | bool | `false` | Use Kubernetes api server cache for pod list requests (reduces api server pressure at scale) |
 | log_level | string | `"info"` |  |
 | max_node_concurrency | int | `10` | Max number of concurrent query requests to the kubernetes API. |
-| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_container_volume_limit_percentage":true,"ephemeral_storage_container_volume_usage":true,"ephemeral_storage_inodes":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true,"gc_batch_size":500,"gc_enabled":false,"gc_interval":5,"port":9100}` | Set metrics you want to enable |
+| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_container_logs_usage":true,"ephemeral_storage_container_rootfs_usage":true,"ephemeral_storage_container_volume_limit_percentage":true,"ephemeral_storage_container_volume_usage":true,"ephemeral_storage_inodes":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true,"gc_batch_size":500,"gc_enabled":false,"gc_interval":5,"port":9100}` | Set metrics you want to enable |
 | metrics.adjusted_polling_rate | bool | `false` | Create the ephemeral_storage_adjusted_polling_rate metrics to report Adjusted Poll Rate in milliseconds. Typically used for testing. |
 | metrics.ephemeral_storage_container_limit_percentage | bool | `true` | Percentage of ephemeral storage used by a container in a pod |
+| metrics.ephemeral_storage_container_logs_usage | bool | `true` | Current logs bytes used/available/capacity for a container in a pod |
+| metrics.ephemeral_storage_container_rootfs_usage | bool | `true` | Current rootfs bytes used/available/capacity for a container in a pod |
 | metrics.ephemeral_storage_container_volume_limit_percentage | bool | `true` | Percentage of ephemeral storage used by a container's volume in a pod |
 | metrics.ephemeral_storage_container_volume_usage | bool | `true` | Current ephemeral storage used by a container's volume in a pod |
 | metrics.ephemeral_storage_inodes | bool | `true` | Current ephemeral inode usage of pod |

--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -124,6 +124,14 @@ spec:
             - name: EPHEMERAL_STORAGE_CONTAINER_LIMIT_PERCENTAGE
               value: "{{ .Values.metrics.ephemeral_storage_container_limit_percentage }}"
               {{- end }}
+              {{- if .Values.metrics.ephemeral_storage_container_rootfs_usage }}
+            - name: EPHEMERAL_STORAGE_CONTAINER_ROOTFS_USAGE
+              value: "{{ .Values.metrics.ephemeral_storage_container_rootfs_usage }}"
+              {{- end }}
+              {{- if .Values.metrics.ephemeral_storage_container_logs_usage }}
+            - name: EPHEMERAL_STORAGE_CONTAINER_LOGS_USAGE
+              value: "{{ .Values.metrics.ephemeral_storage_container_logs_usage }}"
+              {{- end }}
               {{- if .Values.metrics.ephemeral_storage_container_volume_usage }}
             - name: EPHEMERAL_STORAGE_CONTAINER_VOLUME_USAGE
               value: "{{ .Values.metrics.ephemeral_storage_container_volume_usage }}"

--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -136,6 +136,14 @@ spec:
             - name: EPHEMERAL_STORAGE_CONTAINER_LIMIT_PERCENTAGE
               value: "{{ .Values.metrics.ephemeral_storage_container_limit_percentage }}"
               {{- end }}
+              {{- if .Values.metrics.ephemeral_storage_container_rootfs_usage }}
+            - name: EPHEMERAL_STORAGE_CONTAINER_ROOTFS_USAGE
+              value: "{{ .Values.metrics.ephemeral_storage_container_rootfs_usage }}"
+              {{- end }}
+              {{- if .Values.metrics.ephemeral_storage_container_logs_usage }}
+            - name: EPHEMERAL_STORAGE_CONTAINER_LOGS_USAGE
+              value: "{{ .Values.metrics.ephemeral_storage_container_logs_usage }}"
+              {{- end }}
               {{- if .Values.metrics.ephemeral_storage_container_volume_usage }}
             - name: EPHEMERAL_STORAGE_CONTAINER_VOLUME_USAGE
               value: "{{ .Values.metrics.ephemeral_storage_container_volume_usage }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
+  repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-exporter
   tag: 1.19.2
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
@@ -30,6 +30,10 @@ metrics:
   port: 9100
   # -- Percentage of ephemeral storage used by a container in a pod
   ephemeral_storage_container_limit_percentage: true
+  # -- Current rootfs bytes used/available/capacity for a container in a pod
+  ephemeral_storage_container_rootfs_usage: true
+  # -- Current logs bytes used/available/capacity for a container in a pod
+  ephemeral_storage_container_logs_usage: true
   # -- Current ephemeral storage used by a container's volume in a pod
   ephemeral_storage_container_volume_usage: true
   # -- Percentage of ephemeral storage used by a container's volume in a pod

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-exporter
+  repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
   tag: 1.19.2
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
+  repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-exporter
   tag: 1.19.2
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
@@ -35,6 +35,10 @@ metrics:
   port: 9100
   # -- Percentage of ephemeral storage used by a container in a pod
   ephemeral_storage_container_limit_percentage: true
+  # -- Current rootfs bytes used/available/capacity for a container in a pod
+  ephemeral_storage_container_rootfs_usage: true
+  # -- Current logs bytes used/available/capacity for a container in a pod
+  ephemeral_storage_container_logs_usage: true
   # -- Current ephemeral storage used by a container's volume in a pod
   ephemeral_storage_container_volume_usage: true
   # -- Percentage of ephemeral storage used by a container's volume in a pod

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -41,6 +41,7 @@ type ephemeralStorageMetrics struct {
 			InodesFree     float64 `json:"inodesFree"`
 			InodesUsed     float64 `json:"inodesUsed"`
 		} `json:"ephemeral-storage"`
+		Containers []pod.ContainerStats `json:"containers,omitempty"`
 
 		Volumes []pod.Volume `json:"volume,omitempty"`
 	}
@@ -75,7 +76,7 @@ func setMetrics(nodeName string) {
 			continue
 		}
 		Node.SetMetrics(nodeName, availableBytes, capacityBytes)
-		Pod.SetMetrics(podName, podNamespace, nodeName, usedBytes, availableBytes, capacityBytes, inodes, inodesFree, inodesUsed, p.Volumes)
+		Pod.SetMetrics(podName, podNamespace, nodeName, usedBytes, availableBytes, capacityBytes, inodes, inodesFree, inodesUsed, p.Volumes, p.Containers)
 	}
 
 	adjustTime := sampleIntervalMill - time.Now().Sub(start).Milliseconds()

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -41,6 +41,7 @@ type ephemeralStorageMetrics struct {
 			InodesFree     float64 `json:"inodesFree"`
 			InodesUsed     float64 `json:"inodesUsed"`
 		} `json:"ephemeral-storage"`
+		Containers []pod.ContainerStats `json:"containers,omitempty"`
 
 		Volumes []pod.Volume `json:"volume,omitempty"`
 	}
@@ -74,7 +75,7 @@ func setMetrics(nodeName string) {
 			continue
 		}
 		Node.SetMetrics(nodeName, availableBytes, capacityBytes)
-		Pod.SetMetrics(podName, podNamespace, nodeName, usedBytes, availableBytes, capacityBytes, inodes, inodesFree, inodesUsed, p.Volumes)
+		Pod.SetMetrics(podName, podNamespace, nodeName, usedBytes, availableBytes, capacityBytes, inodes, inodesFree, inodesUsed, p.Volumes, p.Containers)
 	}
 
 	adjustTime := sampleIntervalMill - time.Since(start).Milliseconds()

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/pkg/dev/util_test.go
+++ b/pkg/dev/util_test.go
@@ -1,0 +1,85 @@
+package dev
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetK8sConfigFromEnv_Unset(t *testing.T) {
+	os.Unsetenv("KUBECONFIG")
+	cfg, err := getK8sConfigFromEnv()
+	if err != nil {
+		t.Errorf("expected nil error when KUBECONFIG unset, got %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil config when KUBECONFIG unset, got %v", cfg)
+	}
+}
+
+func TestGetK8sConfigFromEnv_ValidPath(t *testing.T) {
+	dir := t.TempDir()
+	kubeconfig := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+  name: test
+users:
+- name: test-user
+  user:
+    token: fake-token
+`
+	if err := os.WriteFile(kubeconfig, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KUBECONFIG", kubeconfig)
+	cfg, err := getK8sConfigFromEnv()
+	if err != nil {
+		t.Fatalf("expected nil error for valid kubeconfig, got %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config for valid kubeconfig")
+	}
+}
+
+func TestGetK8sConfigFromEnv_InvalidPath(t *testing.T) {
+	t.Setenv("KUBECONFIG", "/nonexistent/path/kubeconfig")
+	cfg, err := getK8sConfigFromEnv()
+	if err == nil {
+		t.Error("expected error for invalid kubeconfig path")
+	}
+	if cfg != nil {
+		t.Errorf("expected nil config on error, got %v", cfg)
+	}
+}
+
+func TestGetK8sConfig_BadKubeconfigPath(t *testing.T) {
+	t.Setenv("KUBECONFIG", "/nonexistent/path/kubeconfig")
+	_, err := getK8sConfig()
+	if err == nil {
+		t.Fatal("expected error for bad KUBECONFIG path")
+	}
+	if !strings.Contains(err.Error(), "KUBECONFIG set but invalid") {
+		t.Errorf("error should contain 'KUBECONFIG set but invalid', got: %v", err)
+	}
+}
+
+func TestGetK8sConfig_FallbackToInCluster(t *testing.T) {
+	os.Unsetenv("KUBECONFIG")
+	cfg, err := getK8sConfig()
+	if err != nil {
+		// Expected when not running in a cluster
+		t.Logf("getK8sConfig() fallback: %v (expected outside cluster)", err)
+		return
+	}
+	t.Log("got in-cluster config")
+	_ = cfg
+}

--- a/pkg/pod/factory.go
+++ b/pkg/pod/factory.go
@@ -22,6 +22,8 @@ type Collector struct {
 	containerVolumeUsage            bool
 	containerLimitsPercentage       bool
 	containerVolumeLimitsPercentage bool
+	containerRootfsUsage            bool
+	containerLogsUsage              bool
 	inodes                          bool
 	lookup                          *map[string]pod
 	lookupMutex                     *sync.RWMutex
@@ -39,6 +41,8 @@ func NewCollector(sampleInterval int64) Collector {
 			"EPHEMERAL_STORAGE_CONTAINER_VOLUME_LIMITS_PERCENTAGE", "false",
 		),
 	)
+	containerRootfsUsage, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_CONTAINER_ROOTFS_USAGE", "false"))
+	containerLogsUsage, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_CONTAINER_LOGS_USAGE", "false"))
 	inodes, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_INODES", "false"))
 	lookup := make(map[string]pod)
 
@@ -46,6 +50,8 @@ func NewCollector(sampleInterval int64) Collector {
 		containerVolumeUsage:            containerVolumeUsage,
 		containerLimitsPercentage:       containerLimitsPercentage,
 		containerVolumeLimitsPercentage: containerVolumeLimitsPercentage,
+		containerRootfsUsage:            containerRootfsUsage,
+		containerLogsUsage:              containerLogsUsage,
 		inodes:                          inodes,
 		lookup:                          &lookup,
 		lookupMutex:                     &lookupMutex,

--- a/pkg/pod/factory.go
+++ b/pkg/pod/factory.go
@@ -23,6 +23,8 @@ type Collector struct {
 	containerVolumeUsage            bool
 	containerLimitsPercentage       bool
 	containerVolumeLimitsPercentage bool
+	containerRootfsUsage            bool
+	containerLogsUsage              bool
 	inodes                          bool
 	lookup                          *map[string]pod
 	lookupMutex                     *sync.RWMutex
@@ -45,6 +47,8 @@ func NewCollector(sampleInterval int64) Collector {
 			"EPHEMERAL_STORAGE_CONTAINER_VOLUME_LIMITS_PERCENTAGE", "false",
 		),
 	)
+	containerRootfsUsage, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_CONTAINER_ROOTFS_USAGE", "false"))
+	containerLogsUsage, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_CONTAINER_LOGS_USAGE", "false"))
 	inodes, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_INODES", "false"))
 	lookup := make(map[string]pod)
 
@@ -62,6 +66,8 @@ func NewCollector(sampleInterval int64) Collector {
 		containerVolumeUsage:            containerVolumeUsage,
 		containerLimitsPercentage:       containerLimitsPercentage,
 		containerVolumeLimitsPercentage: containerVolumeLimitsPercentage,
+		containerRootfsUsage:            containerRootfsUsage,
+		containerLogsUsage:              containerLogsUsage,
 		inodes:                          inodes,
 		lookup:                          &lookup,
 		lookupMutex:                     &lookupMutex,

--- a/pkg/pod/k8s_test.go
+++ b/pkg/pod/k8s_test.go
@@ -1,0 +1,74 @@
+package pod
+
+import (
+	"testing"
+)
+
+func TestGetPodsListOptions(t *testing.T) {
+	tests := []struct {
+		name              string
+		listPodsWithCache bool
+		deployAsDaemonSet bool
+		currentNodeName   string
+		wantResourceVer   string
+		wantFieldSelector string
+		wantLimit         int64
+	}{
+		{
+			name:              "defaults",
+			listPodsWithCache: false,
+			deployAsDaemonSet: false,
+			currentNodeName:   "",
+			wantResourceVer:   "",
+			wantFieldSelector: "",
+			wantLimit:         500,
+		},
+		{
+			name:              "cache only",
+			listPodsWithCache: true,
+			deployAsDaemonSet: false,
+			currentNodeName:   "",
+			wantResourceVer:   "0",
+			wantFieldSelector: "",
+			wantLimit:         500,
+		},
+		{
+			name:              "daemonset only",
+			listPodsWithCache: false,
+			deployAsDaemonSet: true,
+			currentNodeName:   "node-1",
+			wantResourceVer:   "",
+			wantFieldSelector: "spec.nodeName=node-1",
+			wantLimit:         500,
+		},
+		{
+			name:              "cache + daemonset",
+			listPodsWithCache: true,
+			deployAsDaemonSet: true,
+			currentNodeName:   "node-2",
+			wantResourceVer:   "0",
+			wantFieldSelector: "spec.nodeName=node-2",
+			wantLimit:         500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Collector{
+				listPodsWithCache: tt.listPodsWithCache,
+				deployAsDaemonSet: tt.deployAsDaemonSet,
+				currentNodeName:   tt.currentNodeName,
+			}
+			opts := c.getPodsListOptions()
+			if opts.ResourceVersion != tt.wantResourceVer {
+				t.Errorf("ResourceVersion = %q, want %q", opts.ResourceVersion, tt.wantResourceVer)
+			}
+			if opts.FieldSelector != tt.wantFieldSelector {
+				t.Errorf("FieldSelector = %q, want %q", opts.FieldSelector, tt.wantFieldSelector)
+			}
+			if opts.Limit != tt.wantLimit {
+				t.Errorf("Limit = %d, want %d", opts.Limit, tt.wantLimit)
+			}
+		})
+	}
+}

--- a/pkg/pod/metrics.go
+++ b/pkg/pod/metrics.go
@@ -15,16 +15,37 @@ var (
 	containerVolumeUsageVec            *prometheus.GaugeVec
 	containerPercentageLimitsVec       *prometheus.GaugeVec
 	containerPercentageVolumeLimitsVec *prometheus.GaugeVec
+	containerRootfsUsedBytesVec        *prometheus.GaugeVec
+	containerRootfsAvailableBytesVec   *prometheus.GaugeVec
+	containerRootfsCapacityBytesVec    *prometheus.GaugeVec
+	containerLogsUsedBytesVec          *prometheus.GaugeVec
+	containerLogsAvailableBytesVec     *prometheus.GaugeVec
+	containerLogsCapacityBytesVec      *prometheus.GaugeVec
 	inodesGaugeVec                     *prometheus.GaugeVec
 	inodesFreeGaugeVec                 *prometheus.GaugeVec
 	inodesUsedGaugeVec                 *prometheus.GaugeVec
 )
+
+type FsStats struct {
+	AvailableBytes float64 `json:"availableBytes"`
+	CapacityBytes  float64 `json:"capacityBytes"`
+	UsedBytes      float64 `json:"usedBytes"`
+	Inodes         float64 `json:"inodes"`
+	InodesFree     float64 `json:"inodesFree"`
+	InodesUsed     float64 `json:"inodesUsed"`
+}
 
 type Volume struct {
 	AvailableBytes int64  `json:"availableBytes"`
 	CapacityBytes  int64  `json:"capacityBytes"`
 	UsedBytes      int    `json:"usedBytes"`
 	Name           string `json:"name"`
+}
+
+type ContainerStats struct {
+	Name   string  `json:"name"`
+	Rootfs FsStats `json:"rootfs"`
+	Logs   FsStats `json:"logs"`
 }
 
 func (cr Collector) createMetrics() {
@@ -109,6 +130,108 @@ func (cr Collector) createMetrics() {
 
 	prometheus.MustRegister(containerPercentageVolumeLimitsVec)
 
+	containerRootfsUsedBytesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_rootfs_used_bytes",
+		Help: "Current rootfs bytes used by a container in a pod",
+	},
+		[]string{
+			// name of pod for Ephemeral Storage
+			"pod_name",
+			// namespace of pod for Ephemeral Storage
+			"pod_namespace",
+			// Name of Node where pod is placed.
+			"node_name",
+			// Name of container
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerRootfsUsedBytesVec)
+
+	containerRootfsAvailableBytesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_rootfs_available_bytes",
+		Help: "Current rootfs bytes available to a container in a pod",
+	},
+		[]string{
+			// name of pod for Ephemeral Storage
+			"pod_name",
+			// namespace of pod for Ephemeral Storage
+			"pod_namespace",
+			// Name of Node where pod is placed.
+			"node_name",
+			// Name of container
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerRootfsAvailableBytesVec)
+
+	containerRootfsCapacityBytesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_rootfs_capacity_bytes",
+		Help: "Current rootfs bytes capacity for a container in a pod",
+	},
+		[]string{
+			// name of pod for Ephemeral Storage
+			"pod_name",
+			// namespace of pod for Ephemeral Storage
+			"pod_namespace",
+			// Name of Node where pod is placed.
+			"node_name",
+			// Name of container
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerRootfsCapacityBytesVec)
+
+	containerLogsUsedBytesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_logs_used_bytes",
+		Help: "Current logs bytes used by a container in a pod",
+	},
+		[]string{
+			// name of pod for Ephemeral Storage
+			"pod_name",
+			// namespace of pod for Ephemeral Storage
+			"pod_namespace",
+			// Name of Node where pod is placed.
+			"node_name",
+			// Name of container
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerLogsUsedBytesVec)
+
+	containerLogsAvailableBytesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_logs_available_bytes",
+		Help: "Current logs bytes available to a container in a pod",
+	},
+		[]string{
+			// name of pod for Ephemeral Storage
+			"pod_name",
+			// namespace of pod for Ephemeral Storage
+			"pod_namespace",
+			// Name of Node where pod is placed.
+			"node_name",
+			// Name of container
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerLogsAvailableBytesVec)
+
+	containerLogsCapacityBytesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_logs_capacity_bytes",
+		Help: "Current logs bytes capacity for a container in a pod",
+	},
+		[]string{
+			// name of pod for Ephemeral Storage
+			"pod_name",
+			// namespace of pod for Ephemeral Storage
+			"pod_namespace",
+			// Name of Node where pod is placed.
+			"node_name",
+			// Name of container
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerLogsCapacityBytesVec)
+
 	inodesGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ephemeral_storage_inodes",
 		Help: "Maximum number of inodes in the pod",
@@ -158,7 +281,7 @@ func (cr Collector) createMetrics() {
 	prometheus.MustRegister(inodesUsedGaugeVec)
 }
 
-func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName string, usedBytes float64, availableBytes float64, capacityBytes float64, inodes float64, inodesFree float64, inodesUsed float64, volumes []Volume) {
+func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName string, usedBytes float64, availableBytes float64, capacityBytes float64, inodes float64, inodesFree float64, inodesUsed float64, volumes []Volume, containers []ContainerStats) {
 
 	var setValue float64
 	cr.lookupMutex.Lock()
@@ -248,6 +371,26 @@ func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName str
 		}
 	}
 
+	if cr.containerRootfsUsage {
+		for _, c := range containers {
+			labels := prometheus.Labels{"pod_namespace": podNamespace,
+				"pod_name": podName, "node_name": nodeName, "container": c.Name}
+			containerRootfsUsedBytesVec.With(labels).Set(c.Rootfs.UsedBytes)
+			containerRootfsAvailableBytesVec.With(labels).Set(c.Rootfs.AvailableBytes)
+			containerRootfsCapacityBytesVec.With(labels).Set(c.Rootfs.CapacityBytes)
+		}
+	}
+
+	if cr.containerLogsUsage {
+		for _, c := range containers {
+			labels := prometheus.Labels{"pod_namespace": podNamespace,
+				"pod_name": podName, "node_name": nodeName, "container": c.Name}
+			containerLogsUsedBytesVec.With(labels).Set(c.Logs.UsedBytes)
+			containerLogsAvailableBytesVec.With(labels).Set(c.Logs.AvailableBytes)
+			containerLogsCapacityBytesVec.With(labels).Set(c.Logs.CapacityBytes)
+		}
+	}
+
 	if cr.podUsage {
 		labels := prometheus.Labels{"pod_namespace": podNamespace,
 			"pod_name": podName, "node_name": nodeName}
@@ -272,6 +415,12 @@ func evictPodByName(p v1.Pod) {
 	inodesGaugeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 	inodesFreeGaugeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 	inodesUsedGaugeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerRootfsUsedBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerRootfsAvailableBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerRootfsCapacityBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerLogsUsedBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerLogsAvailableBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerLogsCapacityBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 
 	// TODO: Look into removing this for loop and delete by pod_name
 	// e.g. containerVolumeUsageVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
@@ -295,4 +444,10 @@ func EvictPodByNode(deleteLabel *prometheus.Labels) {
 	containerVolumeUsageVec.DeletePartialMatch(*deleteLabel)
 	containerPercentageLimitsVec.DeletePartialMatch(*deleteLabel)
 	containerPercentageVolumeLimitsVec.DeletePartialMatch(*deleteLabel)
+	containerRootfsUsedBytesVec.DeletePartialMatch(*deleteLabel)
+	containerRootfsAvailableBytesVec.DeletePartialMatch(*deleteLabel)
+	containerRootfsCapacityBytesVec.DeletePartialMatch(*deleteLabel)
+	containerLogsUsedBytesVec.DeletePartialMatch(*deleteLabel)
+	containerLogsAvailableBytesVec.DeletePartialMatch(*deleteLabel)
+	containerLogsCapacityBytesVec.DeletePartialMatch(*deleteLabel)
 }

--- a/pkg/pod/metrics.go
+++ b/pkg/pod/metrics.go
@@ -21,18 +21,26 @@ var (
 	containerLogsUsedBytesVec          *prometheus.GaugeVec
 	containerLogsAvailableBytesVec     *prometheus.GaugeVec
 	containerLogsCapacityBytesVec      *prometheus.GaugeVec
+	containerRootfsUsagePercentageVec  *prometheus.GaugeVec
+	containerLogsUsagePercentageVec    *prometheus.GaugeVec
+	containerRootfsInodesVec           *prometheus.GaugeVec
+	containerRootfsInodesFreeVec       *prometheus.GaugeVec
+	containerRootfsInodesUsedVec       *prometheus.GaugeVec
+	containerLogsInodesVec             *prometheus.GaugeVec
+	containerLogsInodesFreeVec         *prometheus.GaugeVec
+	containerLogsInodesUsedVec         *prometheus.GaugeVec
 	inodesGaugeVec                     *prometheus.GaugeVec
 	inodesFreeGaugeVec                 *prometheus.GaugeVec
 	inodesUsedGaugeVec                 *prometheus.GaugeVec
 )
 
 type FsStats struct {
-	AvailableBytes float64 `json:"availableBytes"`
-	CapacityBytes  float64 `json:"capacityBytes"`
-	UsedBytes      float64 `json:"usedBytes"`
-	Inodes         float64 `json:"inodes"`
-	InodesFree     float64 `json:"inodesFree"`
-	InodesUsed     float64 `json:"inodesUsed"`
+	AvailableBytes int64 `json:"availableBytes"`
+	CapacityBytes  int64 `json:"capacityBytes"`
+	UsedBytes      int   `json:"usedBytes"`
+	Inodes         int64 `json:"inodes"`
+	InodesFree     int64 `json:"inodesFree"`
+	InodesUsed     int64 `json:"inodesUsed"`
 }
 
 type Volume struct {
@@ -232,6 +240,110 @@ func (cr Collector) createMetrics() {
 	)
 	prometheus.MustRegister(containerLogsCapacityBytesVec)
 
+	containerRootfsUsagePercentageVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_rootfs_usage_percentage",
+		Help: "Percentage of rootfs capacity used by a container in a pod",
+	},
+		[]string{
+			"pod_name",
+			"pod_namespace",
+			"node_name",
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerRootfsUsagePercentageVec)
+
+	containerLogsUsagePercentageVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_logs_usage_percentage",
+		Help: "Percentage of logs capacity used by a container in a pod",
+	},
+		[]string{
+			"pod_name",
+			"pod_namespace",
+			"node_name",
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerLogsUsagePercentageVec)
+
+	containerRootfsInodesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_rootfs_inodes",
+		Help: "Maximum number of inodes in the container rootfs",
+	},
+		[]string{
+			"pod_name",
+			"pod_namespace",
+			"node_name",
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerRootfsInodesVec)
+
+	containerRootfsInodesFreeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_rootfs_inodes_free",
+		Help: "Number of free inodes in the container rootfs",
+	},
+		[]string{
+			"pod_name",
+			"pod_namespace",
+			"node_name",
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerRootfsInodesFreeVec)
+
+	containerRootfsInodesUsedVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_rootfs_inodes_used",
+		Help: "Number of used inodes in the container rootfs",
+	},
+		[]string{
+			"pod_name",
+			"pod_namespace",
+			"node_name",
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerRootfsInodesUsedVec)
+
+	containerLogsInodesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_logs_inodes",
+		Help: "Maximum number of inodes in the container logs",
+	},
+		[]string{
+			"pod_name",
+			"pod_namespace",
+			"node_name",
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerLogsInodesVec)
+
+	containerLogsInodesFreeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_logs_inodes_free",
+		Help: "Number of free inodes in the container logs",
+	},
+		[]string{
+			"pod_name",
+			"pod_namespace",
+			"node_name",
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerLogsInodesFreeVec)
+
+	containerLogsInodesUsedVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ephemeral_storage_container_logs_inodes_used",
+		Help: "Number of used inodes in the container logs",
+	},
+		[]string{
+			"pod_name",
+			"pod_namespace",
+			"node_name",
+			"container",
+		},
+	)
+	prometheus.MustRegister(containerLogsInodesUsedVec)
+
 	inodesGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ephemeral_storage_inodes",
 		Help: "Maximum number of inodes in the pod",
@@ -375,9 +487,17 @@ func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName str
 		for _, c := range containers {
 			labels := prometheus.Labels{"pod_namespace": podNamespace,
 				"pod_name": podName, "node_name": nodeName, "container": c.Name}
-			containerRootfsUsedBytesVec.With(labels).Set(c.Rootfs.UsedBytes)
-			containerRootfsAvailableBytesVec.With(labels).Set(c.Rootfs.AvailableBytes)
-			containerRootfsCapacityBytesVec.With(labels).Set(c.Rootfs.CapacityBytes)
+			containerRootfsUsedBytesVec.With(labels).Set(float64(c.Rootfs.UsedBytes))
+			containerRootfsAvailableBytesVec.With(labels).Set(float64(c.Rootfs.AvailableBytes))
+			containerRootfsCapacityBytesVec.With(labels).Set(float64(c.Rootfs.CapacityBytes))
+			if c.Rootfs.CapacityBytes > 0 {
+				containerRootfsUsagePercentageVec.With(labels).Set(float64(c.Rootfs.UsedBytes) / float64(c.Rootfs.CapacityBytes) * 100.0)
+			}
+			if cr.inodes {
+				containerRootfsInodesVec.With(labels).Set(float64(c.Rootfs.Inodes))
+				containerRootfsInodesFreeVec.With(labels).Set(float64(c.Rootfs.InodesFree))
+				containerRootfsInodesUsedVec.With(labels).Set(float64(c.Rootfs.InodesUsed))
+			}
 		}
 	}
 
@@ -385,9 +505,17 @@ func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName str
 		for _, c := range containers {
 			labels := prometheus.Labels{"pod_namespace": podNamespace,
 				"pod_name": podName, "node_name": nodeName, "container": c.Name}
-			containerLogsUsedBytesVec.With(labels).Set(c.Logs.UsedBytes)
-			containerLogsAvailableBytesVec.With(labels).Set(c.Logs.AvailableBytes)
-			containerLogsCapacityBytesVec.With(labels).Set(c.Logs.CapacityBytes)
+			containerLogsUsedBytesVec.With(labels).Set(float64(c.Logs.UsedBytes))
+			containerLogsAvailableBytesVec.With(labels).Set(float64(c.Logs.AvailableBytes))
+			containerLogsCapacityBytesVec.With(labels).Set(float64(c.Logs.CapacityBytes))
+			if c.Logs.CapacityBytes > 0 {
+				containerLogsUsagePercentageVec.With(labels).Set(float64(c.Logs.UsedBytes) / float64(c.Logs.CapacityBytes) * 100.0)
+			}
+			if cr.inodes {
+				containerLogsInodesVec.With(labels).Set(float64(c.Logs.Inodes))
+				containerLogsInodesFreeVec.With(labels).Set(float64(c.Logs.InodesFree))
+				containerLogsInodesUsedVec.With(labels).Set(float64(c.Logs.InodesUsed))
+			}
 		}
 	}
 
@@ -421,6 +549,14 @@ func evictPodByName(p v1.Pod) {
 	containerLogsUsedBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 	containerLogsAvailableBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 	containerLogsCapacityBytesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerRootfsUsagePercentageVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerLogsUsagePercentageVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerRootfsInodesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerRootfsInodesFreeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerRootfsInodesUsedVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerLogsInodesVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerLogsInodesFreeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerLogsInodesUsedVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 
 	// TODO: Look into removing this for loop and delete by pod_name
 	// e.g. containerVolumeUsageVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
@@ -450,4 +586,12 @@ func EvictPodByNode(deleteLabel *prometheus.Labels) {
 	containerLogsUsedBytesVec.DeletePartialMatch(*deleteLabel)
 	containerLogsAvailableBytesVec.DeletePartialMatch(*deleteLabel)
 	containerLogsCapacityBytesVec.DeletePartialMatch(*deleteLabel)
+	containerRootfsUsagePercentageVec.DeletePartialMatch(*deleteLabel)
+	containerLogsUsagePercentageVec.DeletePartialMatch(*deleteLabel)
+	containerRootfsInodesVec.DeletePartialMatch(*deleteLabel)
+	containerRootfsInodesFreeVec.DeletePartialMatch(*deleteLabel)
+	containerRootfsInodesUsedVec.DeletePartialMatch(*deleteLabel)
+	containerLogsInodesVec.DeletePartialMatch(*deleteLabel)
+	containerLogsInodesFreeVec.DeletePartialMatch(*deleteLabel)
+	containerLogsInodesUsedVec.DeletePartialMatch(*deleteLabel)
 }

--- a/pkg/pod/metrics_test.go
+++ b/pkg/pod/metrics_test.go
@@ -1,0 +1,138 @@
+package pod
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRootfsLogsMetrics(t *testing.T) {
+	mu := &sync.RWMutex{}
+	cr := Collector{
+		containerRootfsUsage: true,
+		containerLogsUsage:   true,
+		inodes:               true,
+		lookup:               &map[string]pod{},
+		lookupMutex:          mu,
+	}
+	cr.createMetrics()
+
+	t.Run("registration", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			vec  *prometheus.GaugeVec
+		}{
+			{"containerRootfsUsagePercentageVec", containerRootfsUsagePercentageVec},
+			{"containerLogsUsagePercentageVec", containerLogsUsagePercentageVec},
+			{"containerRootfsInodesVec", containerRootfsInodesVec},
+			{"containerRootfsInodesFreeVec", containerRootfsInodesFreeVec},
+			{"containerRootfsInodesUsedVec", containerRootfsInodesUsedVec},
+			{"containerLogsInodesVec", containerLogsInodesVec},
+			{"containerLogsInodesFreeVec", containerLogsInodesFreeVec},
+			{"containerLogsInodesUsedVec", containerLogsInodesUsedVec},
+		} {
+			if tc.vec == nil {
+				t.Errorf("%s not registered", tc.name)
+			}
+		}
+	})
+
+	t.Run("set_values", func(t *testing.T) {
+		containers := []ContainerStats{
+			{
+				Name: "c1",
+				Rootfs: FsStats{
+					AvailableBytes: 7500,
+					CapacityBytes:  10000,
+					UsedBytes:      2500,
+					Inodes:         1000,
+					InodesFree:     800,
+					InodesUsed:     200,
+				},
+				Logs: FsStats{
+					AvailableBytes: 5000,
+					CapacityBytes:  8000,
+					UsedBytes:      3000,
+					Inodes:         500,
+					InodesFree:     200,
+					InodesUsed:     300,
+				},
+			},
+		}
+
+		cr.SetMetrics("p1", "ns1", "n1", 0, 0, 0, 0, 0, 0, nil, containers)
+
+		expected := strings.NewReader(`
+			# HELP ephemeral_storage_container_rootfs_usage_percentage Percentage of rootfs capacity used by a container in a pod
+			# TYPE ephemeral_storage_container_rootfs_usage_percentage gauge
+			ephemeral_storage_container_rootfs_usage_percentage{container="c1",node_name="n1",pod_name="p1",pod_namespace="ns1"} 25
+			# HELP ephemeral_storage_container_logs_usage_percentage Percentage of logs capacity used by a container in a pod
+			# TYPE ephemeral_storage_container_logs_usage_percentage gauge
+			ephemeral_storage_container_logs_usage_percentage{container="c1",node_name="n1",pod_name="p1",pod_namespace="ns1"} 37.5
+			# HELP ephemeral_storage_container_rootfs_inodes Maximum number of inodes in the container rootfs
+			# TYPE ephemeral_storage_container_rootfs_inodes gauge
+			ephemeral_storage_container_rootfs_inodes{container="c1",node_name="n1",pod_name="p1",pod_namespace="ns1"} 1000
+			# HELP ephemeral_storage_container_rootfs_inodes_free Number of free inodes in the container rootfs
+			# TYPE ephemeral_storage_container_rootfs_inodes_free gauge
+			ephemeral_storage_container_rootfs_inodes_free{container="c1",node_name="n1",pod_name="p1",pod_namespace="ns1"} 800
+			# HELP ephemeral_storage_container_rootfs_inodes_used Number of used inodes in the container rootfs
+			# TYPE ephemeral_storage_container_rootfs_inodes_used gauge
+			ephemeral_storage_container_rootfs_inodes_used{container="c1",node_name="n1",pod_name="p1",pod_namespace="ns1"} 200
+			# HELP ephemeral_storage_container_logs_inodes Maximum number of inodes in the container logs
+			# TYPE ephemeral_storage_container_logs_inodes gauge
+			ephemeral_storage_container_logs_inodes{container="c1",node_name="n1",pod_name="p1",pod_namespace="ns1"} 500
+			# HELP ephemeral_storage_container_logs_inodes_free Number of free inodes in the container logs
+			# TYPE ephemeral_storage_container_logs_inodes_free gauge
+			ephemeral_storage_container_logs_inodes_free{container="c1",node_name="n1",pod_name="p1",pod_namespace="ns1"} 200
+			# HELP ephemeral_storage_container_logs_inodes_used Number of used inodes in the container logs
+			# TYPE ephemeral_storage_container_logs_inodes_used gauge
+			ephemeral_storage_container_logs_inodes_used{container="c1",node_name="n1",pod_name="p1",pod_namespace="ns1"} 300
+		`)
+
+		metricNames := []string{
+			"ephemeral_storage_container_rootfs_usage_percentage",
+			"ephemeral_storage_container_logs_usage_percentage",
+			"ephemeral_storage_container_rootfs_inodes",
+			"ephemeral_storage_container_rootfs_inodes_free",
+			"ephemeral_storage_container_rootfs_inodes_used",
+			"ephemeral_storage_container_logs_inodes",
+			"ephemeral_storage_container_logs_inodes_free",
+			"ephemeral_storage_container_logs_inodes_used",
+		}
+
+		if err := testutil.GatherAndCompare(prometheus.DefaultGatherer, expected, metricNames...); err != nil {
+			t.Fatalf("metric values mismatch: %v", err)
+		}
+	})
+
+	t.Run("eviction", func(t *testing.T) {
+		evictPodByName(v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p1",
+				Namespace: "ns1",
+			},
+		})
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_usage_percentage",
+			"ephemeral_storage_container_logs_usage_percentage",
+			"ephemeral_storage_container_rootfs_inodes",
+			"ephemeral_storage_container_rootfs_inodes_free",
+			"ephemeral_storage_container_rootfs_inodes_used",
+			"ephemeral_storage_container_logs_inodes",
+			"ephemeral_storage_container_logs_inodes_free",
+			"ephemeral_storage_container_logs_inodes_used",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count > 0 {
+			t.Errorf("expected 0 time series after eviction, got %d", count)
+		}
+	})
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -64,6 +64,8 @@ function main() {
     "prometheus.rules.enable=true"
     "metrics.gc_interval=1"
     "metrics.gc_enabled=true"
+    "metrics.ephemeral_storage_container_rootfs_usage=true"
+    "metrics.ephemeral_storage_container_logs_usage=true"
   )
 
   if [[ $ENV =~ "e2e" ]]; then

--- a/tests/charts/observability/README.md
+++ b/tests/charts/observability/README.md
@@ -1,0 +1,88 @@
+## Helm Install
+
+```bash
+helm repo add k8s-ephemeral-storage-metrics https://jmcgrath207.github.io/k8s-ephemeral-storage-metrics/chart
+helm repo update
+helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral-storage-metrics
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| grafana-operator.enabled | bool | `true` |  |
+| kube-prometheus-stack.alertmanager.enabled | bool | `false` |  |
+| kube-prometheus-stack.enabled | bool | `true` |  |
+| kube-prometheus-stack.grafana.enabled | bool | `false` |  |
+| kube-prometheus-stack.kube-state-metrics.enabled | bool | `false` |  |
+| kube-prometheus-stack.kubeApiServer.enabled | bool | `false` |  |
+| kube-prometheus-stack.kubeControllerManager.enabled | bool | `false` |  |
+| kube-prometheus-stack.kubelet.enabled | bool | `false` |  |
+| kube-prometheus-stack.kubernetesServiceMonitors.enabled | bool | `false` |  |
+| kube-prometheus-stack.prometheus-node-exporter.enabled | bool | `false` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues | bool | `false` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.probeSelectorNilUsesHelmValues | bool | `false` |  |
+| kube-prometheus-stack.prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues | bool | `false` |  |
+| pyroscope.enabled | bool | `true` |  |
+
+## Prometheus alert rules
+
+To prevent from multiple kind of alerts being fired for a single container or
+emptyDir volume when both `prometheus.enable` and `prometheus.rules.enable` are
+on, add the following [inhibition
+rules](https://prometheus.io/docs/alerting/latest/configuration/#inhibition-related-settings)
+to your Alert Manager config:
+
+```yaml
+- source_matchers:
+    - alertname="EphemeralStorageVolumeFilledUp"
+  target_matchers:
+    - severity="warning"
+    - alertname="EphemeralStorageVolumeFillingUp"
+  equal:
+    - pod_namespace
+    - pod_name
+    - volume_name
+- source_matchers:
+    - alertname="ContainerEphemeralStorageUsageAtLimit"
+  target_matchers:
+    - severity="warning"
+    - alertname="ContainerEphemeralStorageUsageReachingLimit"
+  equal:
+    - pod_namespace
+    - pod_name
+    - exported_container
+```
+
+## Contribute
+
+### Start minikube
+```bash
+make new_minikube
+```
+
+### Run locally
+```bash
+make deploy_local
+```
+
+### Run locally with Delve Debug
+```bash
+make deploy_debug
+```
+Then connect to `localhost:30002` with [delve](https://github.com/go-delve/delve) or your IDE.
+
+### Run e2e Test
+```bash
+make deploy_e2e
+```
+
+### Debug e2e
+```bash
+make deploy_e2e_debug
+```
+Then run a debug against [deployment_test.go](tests/e2e/deployment_test.go)
+
+## License
+
+This project is licensed under the [MIT License](https://opensource.org/licenses/MIT). See the `LICENSE` file for more details.

--- a/tests/e2e/deployment_test.go
+++ b/tests/e2e/deployment_test.go
@@ -232,6 +232,15 @@ func getContainerVolumeUsage(podName string) float64 {
 	return currentPodSize
 }
 
+func getContainerRootfsUsagePercentage(podName string) float64 {
+	output := requestPrometheusString()
+	re := regexp.MustCompile(
+		fmt.Sprintf(`ephemeral_storage_container_rootfs_usage_percentage.+container="%s".+\}\s(.+)`, podName))
+	match := re.FindAllStringSubmatch(output, 2)
+	currentPodSize, _ := strconv.ParseFloat(match[0][1], 64)
+	return currentPodSize
+}
+
 func WatchEphemeralSize(podName string, desiredSizeChange float64, timeout time.Duration, getPodSize getPodSize) {
 	// Watch Prometheus Metrics until the ephemeral storage shrinks or grows to a certain desiredSizeChange.
 	var currentPodSize float64
@@ -328,6 +337,20 @@ var _ = ginkgo.Describe("Test Metrics\n", func() {
 				"ephemeral_storage_inodes",
 				"ephemeral_storage_inodes_free",
 				"ephemeral_storage_inodes_used",
+				"ephemeral_storage_container_rootfs_used_bytes",
+				"ephemeral_storage_container_rootfs_available_bytes",
+				"ephemeral_storage_container_rootfs_capacity_bytes",
+				"ephemeral_storage_container_logs_used_bytes",
+				"ephemeral_storage_container_logs_available_bytes",
+				"ephemeral_storage_container_logs_capacity_bytes",
+				"ephemeral_storage_container_rootfs_usage_percentage",
+				"ephemeral_storage_container_logs_usage_percentage",
+				"ephemeral_storage_container_rootfs_inodes",
+				"ephemeral_storage_container_rootfs_inodes_free",
+				"ephemeral_storage_container_rootfs_inodes_used",
+				"ephemeral_storage_container_logs_inodes",
+				"ephemeral_storage_container_logs_inodes_free",
+				"ephemeral_storage_container_logs_inodes_used",
 			)
 			checkPrometheus(checkSlice, false)
 		})
@@ -379,6 +402,14 @@ var _ = ginkgo.Describe("Test Metrics\n", func() {
 		})
 		ginkgo.Specify("\nWatch Pod shrink to 0.2 percent", func() {
 			WatchEphemeralSize("shrink-test", 100000, time.Second*180, getContainerVolumeUsage)
+		})
+	})
+	ginkgo.Context("Observe change in ephemeral_storage_container_rootfs_usage_percentage metric\n", func() {
+		ginkgo.Specify("\nWatch Pod grow to 0.2 percent", func() {
+			WatchEphemeralSize("grow-test", 0.2, time.Second*180, getContainerRootfsUsagePercentage)
+		})
+		ginkgo.Specify("\nWatch Pod shrink to 0.2 percent", func() {
+			WatchEphemeralSize("shrink-test", 0.2, time.Second*180, getContainerRootfsUsagePercentage)
 		})
 	})
 	ginkgo.Context("\nMake sure percentage is not over 100", func() {

--- a/tests/e2e/deployment_test.go
+++ b/tests/e2e/deployment_test.go
@@ -232,10 +232,10 @@ func getContainerVolumeUsage(podName string) float64 {
 	return currentPodSize
 }
 
-func getContainerRootfsUsagePercentage(podName string) float64 {
+func getContainerRootfsUsedBytes(podName string) float64 {
 	output := requestPrometheusString()
 	re := regexp.MustCompile(
-		fmt.Sprintf(`ephemeral_storage_container_rootfs_usage_percentage.+container="%s".+\}\s(.+)`, podName))
+		fmt.Sprintf(`ephemeral_storage_container_rootfs_used_bytes.+container="%s".+\}\s(.+)`, podName))
 	match := re.FindAllStringSubmatch(output, 2)
 	currentPodSize, _ := strconv.ParseFloat(match[0][1], 64)
 	return currentPodSize
@@ -404,12 +404,12 @@ var _ = ginkgo.Describe("Test Metrics\n", func() {
 			WatchEphemeralSize("shrink-test", 100000, time.Second*180, getContainerVolumeUsage)
 		})
 	})
-	ginkgo.Context("Observe change in ephemeral_storage_container_rootfs_usage_percentage metric\n", func() {
+	ginkgo.Context("Observe change in ephemeral_storage_container_rootfs_used_bytes metric\n", func() {
 		ginkgo.Specify("\nWatch Pod grow to 0.2 percent", func() {
-			WatchEphemeralSize("grow-test", 0.2, time.Second*180, getContainerRootfsUsagePercentage)
+			WatchEphemeralSize("grow-test", 100000, time.Second*180, getContainerRootfsUsedBytes)
 		})
 		ginkgo.Specify("\nWatch Pod shrink to 0.2 percent", func() {
-			WatchEphemeralSize("shrink-test", 0.2, time.Second*180, getContainerRootfsUsagePercentage)
+			WatchEphemeralSize("shrink-test", 100000, time.Second*180, getContainerRootfsUsedBytes)
 		})
 	})
 	ginkgo.Context("\nMake sure percentage is not over 100", func() {


### PR DESCRIPTION
# Summary

This PR adds container-level rootfs and logs ephemeral storage metrics

New container metrics:
      - ephemeral_storage_container_rootfs_used_bytes
      - ephemeral_storage_container_rootfs_available_bytes
      - ephemeral_storage_container_rootfs_capacity_bytes
      - ephemeral_storage_container_logs_used_bytes
      - ephemeral_storage_container_logs_available_bytes
      - ephemeral_storage_container_logs_capacity_bytes

This will allow to accurately calculate the ephemeral storage usage of the containers (volume metrics already exist)