### PR TITLE
feat: add serviceAnnotations support to metrics Service

### DIFF
--- a/chart/templates/metrics.yaml
+++ b/chart/templates/metrics.yaml
@@ -52,6 +52,10 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   labels:
     {{- include "chart.labels" . | nindent 6 }}
+  {{- with .Values.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,6 +104,9 @@ resources: {}
 
 podAnnotations: {}
 
+# -- Annotations to add to the metrics Service
+serviceAnnotations: {}
+
 nodeSelector: {}
 
 affinity: {}


### PR DESCRIPTION
## Summary

- Adds a `serviceAnnotations` value (defaulting to `{}`) that is applied to the `Service` metadata, mirroring the existing `podAnnotations` pattern.
- This allows users to set arbitrary annotations on the Service without modifying the chart template.

## Motivation

Some Kubernetes environments enforce or benefit from service-level annotations. A common example is `service.kubernetes.io/topology-mode: Auto` for [Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/), which reduces cross-AZ traffic costs by preferring same-zone endpoints. Without this value, users must either fork the chart or find a workaround.

## Usage

```yaml
serviceAnnotations:
  service.kubernetes.io/topology-mode: Auto
```
