### PR TITLE
Improve K8s API efficiency: caching, node filtering, and flapping fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ fabric.properties
 # vendor/
 
 chart/k8s-ephemeral-storage-metrics-*.tgz
+
+# vscode
+.vscode/

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -47,6 +47,7 @@ type ephemeralStorageMetrics struct {
 }
 
 func setMetrics(nodeName string) {
+	defer Node.ReleaseInFlight(nodeName)
 
 	var data ephemeralStorageMetrics
 
@@ -102,7 +103,12 @@ func getMetrics() {
 		nodeSlice := Node.Set.ToSlice()
 
 		for _, node := range nodeSlice {
-			_ = p.Invoke(node)
+			if !Node.TryAcquireInFlight(node) {
+				continue
+			}
+			if err := p.Invoke(node); err != nil {
+				Node.ReleaseInFlight(node)
+			}
 		}
 
 		time.Sleep(time.Duration(sampleInterval) * time.Second)

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/pkg/dev/util.go
+++ b/pkg/dev/util.go
@@ -60,6 +60,8 @@ func SetK8sClient() {
 		panic(err)
 	}
 
+	config.UserAgent = "k8s-ephemeral-storage-metrics"
+
 	scrapeFromKubelet, _ := strconv.ParseBool(GetEnv("SCRAPE_FROM_KUBELET", "false"))
 	if scrapeFromKubelet {
 		setScrapeFromKubelet(config)

--- a/pkg/dev/util.go
+++ b/pkg/dev/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -54,11 +55,9 @@ func setScrapeFromKubelet(config *rest.Config) {
 }
 
 func SetK8sClient() {
-
-	config, err := rest.InClusterConfig()
+	config, err := getK8sConfig()
 	if err != nil {
-		log.Error().Msg("Failed to get rest config for in cluster client")
-		panic(err.Error())
+		panic(err)
 	}
 
 	scrapeFromKubelet, _ := strconv.ParseBool(GetEnv("SCRAPE_FROM_KUBELET", "false"))
@@ -82,6 +81,21 @@ func SetK8sClient() {
 	}
 	log.Debug().Msg("Successful got the in cluster client")
 
+}
+
+func getK8sConfig() (*rest.Config, error) {
+	if config, err := getK8sConfigFromEnv(); err == nil {
+		return config, nil
+	}
+	return rest.InClusterConfig()
+}
+
+func getK8sConfigFromEnv() (*rest.Config, error) {
+	path := os.Getenv("KUBECONFIG")
+	if path == "" {
+		return nil, fmt.Errorf("KUBECONFIG is not set")
+	}
+	return clientcmd.BuildConfigFromFlags("", path)
 }
 
 type LineInfoHook struct{}

--- a/pkg/dev/util.go
+++ b/pkg/dev/util.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	Clientset *kubernetes.Clientset
-	ClientRaw *http.Client
-	ClientAno *http.Client
+	Clientset          *kubernetes.Clientset
+	ClientRaw          *http.Client
+	ClientAno          *http.Client
+	UseAPIServerCache  bool
 )
 
 func GetEnv(key, fallback string) string {
@@ -61,6 +62,8 @@ func SetK8sClient() {
 	}
 
 	config.UserAgent = "k8s-ephemeral-storage-metrics"
+
+	UseAPIServerCache, _ = strconv.ParseBool(GetEnv("USE_API_SERVER_CACHE", "false"))
 
 	scrapeFromKubelet, _ := strconv.ParseBool(GetEnv("SCRAPE_FROM_KUBELET", "false"))
 	if scrapeFromKubelet {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,11 @@
+package env
+
+import "github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/dev"
+
+func DeployAsDaemonSet() bool {
+	return dev.GetEnv("DEPLOY_TYPE", "DaemonSet") == "DaemonSet"
+}
+
+func CurrentNodeName() string {
+	return dev.GetEnv("CURRENT_NODE_NAME", "")
+}

--- a/pkg/node/cooldown.go
+++ b/pkg/node/cooldown.go
@@ -1,0 +1,42 @@
+package node
+
+import (
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+func (n *Node) TryAcquireInFlight(nodeName string) bool {
+	_, loaded := n.inFlight.LoadOrStore(nodeName, struct{}{})
+	return !loaded
+}
+
+func (n *Node) ReleaseInFlight(nodeName string) {
+	n.inFlight.Delete(nodeName)
+}
+
+func (n *Node) RecordFailure(nodeName string) {
+	n.failureCooldown.Store(nodeName, n.timeNow())
+}
+
+func (n *Node) IsInCooldown(nodeName string) bool {
+	val, ok := n.failureCooldown.Load(nodeName)
+	if !ok {
+		return false
+	}
+	failedAt := val.(time.Time)
+	cooldownDuration := time.Duration(n.cooldownMultiplier*n.sampleInterval) * time.Second
+	if n.timeNow().Sub(failedAt) < cooldownDuration {
+		return true
+	}
+	n.failureCooldown.Delete(nodeName)
+	return false
+}
+
+func (n *Node) ClearCooldown(nodeName string) {
+	n.failureCooldown.Delete(nodeName)
+}
+
+func (n *Node) logCooldownSkip(nodeName string) {
+	log.Debug().Msgf("Node %s still in failure cooldown, skipping re-add", nodeName)
+}

--- a/pkg/node/factory.go
+++ b/pkg/node/factory.go
@@ -29,6 +29,7 @@ type Node struct {
 	sampleInterval          int64
 	scrapeFromKubelet       bool
 	kubeletReadOnlyPort     int
+	nodeLabelSelector       string
 	Set                     mapset.Set[string]
 	KubeletEndpoint         *sync.Map // key=nodeName val=kubeletEndpoint
 	WaitGroup               *sync.WaitGroup
@@ -44,6 +45,7 @@ func NewCollector(sampleInterval int64) Node {
 	maxNodeQueryConcurrency, _ := strconv.Atoi(dev.GetEnv("MAX_NODE_CONCURRENCY", "10"))
 	scrapeFromKubelet, _ := strconv.ParseBool(dev.GetEnv("SCRAPE_FROM_KUBELET", "false"))
 	kubeletReadOnlyPort, _ := strconv.Atoi(dev.GetEnv("KUBELET_READONLY_PORT", "0"))
+	nodeLabelSelector := dev.GetEnv("NODE_LABEL_SELECTOR", "")
 	set := mapset.NewSet[string]()
 	mp := &sync.Map{}
 
@@ -62,6 +64,7 @@ func NewCollector(sampleInterval int64) Node {
 		sampleInterval:          sampleInterval,
 		scrapeFromKubelet:       scrapeFromKubelet,
 		kubeletReadOnlyPort:     kubeletReadOnlyPort,
+		nodeLabelSelector:       nodeLabelSelector,
 		Set:                     set,
 		KubeletEndpoint:         mp,
 		WaitGroup:               &waitGroup,
@@ -98,8 +101,9 @@ func (n Node) gcMetrics(interval int64, batchSize int64) {
 				nodes, err := dev.Clientset.CoreV1().Nodes().List(
 					context.Background(),
 					metav1.ListOptions{
-						Limit:    batchSize,
-						Continue: paginationContinue,
+						Limit:         batchSize,
+						Continue:      paginationContinue,
+						LabelSelector: n.nodeLabelSelector,
 					},
 				)
 				if err != nil {

--- a/pkg/node/factory.go
+++ b/pkg/node/factory.go
@@ -33,6 +33,10 @@ type Node struct {
 	Set                     mapset.Set[string]
 	KubeletEndpoint         *sync.Map // key=nodeName val=kubeletEndpoint
 	WaitGroup               *sync.WaitGroup
+	inFlight                *sync.Map          // tracks nodes currently being queried
+	failureCooldown         *sync.Map          // key=nodeName val=time.Time of last failure
+	cooldownMultiplier      int64              // multiplier for sampleInterval to compute cooldown duration
+	timeNow                 func() time.Time   // injectable clock for testing
 }
 
 func NewCollector(sampleInterval int64) Node {
@@ -46,6 +50,10 @@ func NewCollector(sampleInterval int64) Node {
 	scrapeFromKubelet, _ := strconv.ParseBool(dev.GetEnv("SCRAPE_FROM_KUBELET", "false"))
 	kubeletReadOnlyPort, _ := strconv.Atoi(dev.GetEnv("KUBELET_READONLY_PORT", "0"))
 	nodeLabelSelector := dev.GetEnv("NODE_LABEL_SELECTOR", "")
+	cooldownMultiplier, _ := strconv.ParseInt(dev.GetEnv("FAILURE_COOLDOWN_MULTIPLIER", "3"), 10, 64)
+	if cooldownMultiplier <= 0 {
+		cooldownMultiplier = 3
+	}
 	set := mapset.NewSet[string]()
 	mp := &sync.Map{}
 
@@ -68,6 +76,10 @@ func NewCollector(sampleInterval int64) Node {
 		Set:                     set,
 		KubeletEndpoint:         mp,
 		WaitGroup:               &waitGroup,
+		inFlight:                &sync.Map{},
+		failureCooldown:         &sync.Map{},
+		cooldownMultiplier:      cooldownMultiplier,
+		timeNow:                 time.Now,
 	}
 	node.createMetrics()
 
@@ -79,12 +91,31 @@ func NewCollector(sampleInterval int64) Node {
 	}
 
 	if node.deployType != "Deployment" {
-		node.Set.Add(dev.GetEnv("CURRENT_NODE_NAME", ""))
+		currentNodeName := dev.GetEnv("CURRENT_NODE_NAME", "")
+		node.Set.Add(currentNodeName)
+		if node.scrapeFromKubelet {
+			node.initKubeletEndpoint(currentNodeName)
+		}
 	} else {
 		go node.Watch()
 	}
 
 	return node
+}
+
+func (n *Node) initKubeletEndpoint(nodeName string) {
+	nodeObj, err := dev.Clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Error().Msgf("Failed to get node %s for kubelet endpoint: %v", nodeName, err)
+		os.Exit(1)
+	}
+	ep := n.getKubeletEndpoint(nodeObj)
+	if ep == "" {
+		log.Error().Msgf("No internal IP found for node %s", nodeName)
+		os.Exit(1)
+	}
+	n.KubeletEndpoint.Store(nodeName, ep)
+	log.Info().Msgf("Kubelet endpoint for node %s: %s", nodeName, ep)
 }
 
 func (n Node) gcMetrics(interval int64, batchSize int64) {
@@ -130,6 +161,7 @@ func (n Node) gcMetrics(interval int64, batchSize int64) {
 				if _, ok := currentNodes[nodeName]; !ok {
 					log.Info().Msgf("Garbage collector removing metrics for deleted node %s", nodeName)
 					n.evict(nodeName)
+					n.ClearCooldown(nodeName)
 					if n.scrapeFromKubelet {
 						n.KubeletEndpoint.Delete(nodeName)
 					}

--- a/pkg/node/factory.go
+++ b/pkg/node/factory.go
@@ -104,7 +104,11 @@ func NewCollector(sampleInterval int64) Node {
 }
 
 func (n *Node) initKubeletEndpoint(nodeName string) {
-	nodeObj, err := dev.Clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	getOpts := metav1.GetOptions{}
+	if dev.UseAPIServerCache {
+		getOpts.ResourceVersion = "0"
+	}
+	nodeObj, err := dev.Clientset.CoreV1().Nodes().Get(context.Background(), nodeName, getOpts)
 	if err != nil {
 		log.Error().Msgf("Failed to get node %s for kubelet endpoint: %v", nodeName, err)
 		os.Exit(1)
@@ -129,13 +133,17 @@ func (n Node) gcMetrics(interval int64, batchSize int64) {
 			paginationContinue := ""
 
 			for {
+				listOpts := metav1.ListOptions{
+					Limit:         batchSize,
+					Continue:      paginationContinue,
+					LabelSelector: n.nodeLabelSelector,
+				}
+				if dev.UseAPIServerCache {
+					listOpts.ResourceVersion = "0"
+				}
 				nodes, err := dev.Clientset.CoreV1().Nodes().List(
 					context.Background(),
-					metav1.ListOptions{
-						Limit:         batchSize,
-						Continue:      paginationContinue,
-						LabelSelector: n.nodeLabelSelector,
-					},
+					listOpts,
 				)
 				if err != nil {
 					log.Error().Msgf("Error getting nodes: %v", err)

--- a/pkg/node/k8s.go
+++ b/pkg/node/k8s.go
@@ -51,7 +51,7 @@ func (n *Node) Query(node string) ([]byte, error) {
 	operation := func() error {
 		var resp *http.Response
 		var err error
-		if !n.scrapeFromKubelet || n.deployType != "Deployment" {
+		if !n.scrapeFromKubelet {
 			content, err = dev.Clientset.RESTClient().Get().AbsPath(fmt.Sprintf("/api/v1/nodes/%s/proxy/stats/summary", node)).DoRaw(context.Background())
 			if err != nil {
 				return err
@@ -86,12 +86,12 @@ func (n *Node) Query(node string) ([]byte, error) {
 
 	if err != nil {
 		log.Warn().Msg(fmt.Sprintf("Failed to fetched proxy stats from node: %s Error: %v", node, err))
-		// Assume the node status is not ready so evict all pods tracked by that node. The Update func in the Node Watcher
-		// will pick the node back up for monitoring again, once the kubelet status reports back ready.
-		n.evict(node)
+		n.RecordFailure(node)
+		n.suspendNode(node)
 		return nil, err
 	}
 
+	n.ClearCooldown(node)
 	return content, nil
 
 }
@@ -115,6 +115,10 @@ func (n *Node) Watch() {
 		AddFunc: func(obj interface{}) {
 			p := obj.(*v1.Node)
 			if checkKubeletStatus(&p.Status.Conditions) {
+				if n.IsInCooldown(p.Name) {
+					n.logCooldownSkip(p.Name)
+					return
+				}
 				n.Set.Add(p.Name)
 				if n.scrapeFromKubelet {
 					n.KubeletEndpoint.Store(p.Name, n.getKubeletEndpoint(p))
@@ -125,6 +129,10 @@ func (n *Node) Watch() {
 			p := newObj.(*v1.Node)
 			// Add nodes back that have changed readiness status.
 			if checkKubeletStatus(&p.Status.Conditions) {
+				if n.IsInCooldown(p.Name) {
+					n.logCooldownSkip(p.Name)
+					return
+				}
 				n.Set.Add(p.Name)
 				if n.scrapeFromKubelet {
 					n.KubeletEndpoint.Store(p.Name, n.getKubeletEndpoint(p))
@@ -134,6 +142,7 @@ func (n *Node) Watch() {
 		DeleteFunc: func(obj interface{}) {
 			p := obj.(*v1.Node)
 			n.evict(p.Name)
+			n.ClearCooldown(p.Name)
 			if n.scrapeFromKubelet {
 				n.KubeletEndpoint.Delete(p.Name)
 			}

--- a/pkg/node/k8s.go
+++ b/pkg/node/k8s.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/dev"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 )
@@ -99,7 +100,14 @@ func (n *Node) Watch() {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	// TODO: break out the sampleInterval into Groups. E.g. nodeSampleInterval, podSampleInterval, metricsSampleInterval
-	sharedInformerFactory := informers.NewSharedInformerFactory(dev.Clientset, time.Duration(n.sampleInterval)*time.Second)
+	var sharedInformerFactory informers.SharedInformerFactory
+	if n.nodeLabelSelector != "" {
+		sharedInformerFactory = informers.NewSharedInformerFactoryWithOptions(dev.Clientset, time.Duration(n.sampleInterval)*time.Second, informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = n.nodeLabelSelector
+		}))
+	} else {
+		sharedInformerFactory = informers.NewSharedInformerFactory(dev.Clientset, time.Duration(n.sampleInterval)*time.Second)
+	}
 	nodeInformer := sharedInformerFactory.Core().V1().Nodes().Informer()
 
 	// Define event handlers for Pod events

--- a/pkg/node/metrics.go
+++ b/pkg/node/metrics.go
@@ -105,3 +105,8 @@ func (n *Node) evict(node string) {
 	pod.EvictPodByNode(&deleteLabel)
 	log.Info().Msgf("Node %s does not exist or is unresponsive. Removed from monitoring", node)
 }
+
+func (n *Node) suspendNode(node string) {
+	n.Set.Remove(node)
+	log.Warn().Msgf("Node %s temporarily removed from polling due to query failure", node)
+}

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,241 @@
+package node
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func newTestNode() *Node {
+	return &Node{
+		Set:              mapset.NewSet[string](),
+		sampleInterval:   1,
+		inFlight:         &sync.Map{},
+		failureCooldown:  &sync.Map{},
+		cooldownMultiplier: 3,
+		timeNow:          time.Now,
+		AdjustedPollingRate: false,
+	}
+}
+
+func init() {
+	nodeAvailableGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "test_ephemeral_storage_node_available",
+	}, []string{"node_name"})
+
+	nodeCapacityGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "test_ephemeral_storage_node_capacity",
+	}, []string{"node_name"})
+
+	nodePercentageGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "test_ephemeral_storage_node_percentage",
+	}, []string{"node_name"})
+}
+
+// --- Fix 1: In-flight deduplication tests ---
+
+func TestTryAcquireInFlight_FirstCall_Succeeds(t *testing.T) {
+	n := newTestNode()
+	if !n.TryAcquireInFlight("nodeA") {
+		t.Fatal("expected first TryAcquireInFlight to succeed")
+	}
+}
+
+func TestTryAcquireInFlight_SecondCall_Blocked(t *testing.T) {
+	n := newTestNode()
+	n.TryAcquireInFlight("nodeA")
+	if n.TryAcquireInFlight("nodeA") {
+		t.Fatal("expected second TryAcquireInFlight to be blocked")
+	}
+}
+
+func TestReleaseInFlight_EnablesReacquisition(t *testing.T) {
+	n := newTestNode()
+	n.TryAcquireInFlight("nodeA")
+	n.ReleaseInFlight("nodeA")
+	if !n.TryAcquireInFlight("nodeA") {
+		t.Fatal("expected TryAcquireInFlight to succeed after release")
+	}
+}
+
+func TestInFlight_DifferentNodes_Independent(t *testing.T) {
+	n := newTestNode()
+	n.TryAcquireInFlight("nodeA")
+	if !n.TryAcquireInFlight("nodeB") {
+		t.Fatal("expected nodeB acquisition to be independent of nodeA")
+	}
+}
+
+func TestInFlight_ConcurrentAccess(t *testing.T) {
+	n := newTestNode()
+	const goroutines = 50
+	var acquired int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if n.TryAcquireInFlight("nodeA") {
+				atomic.AddInt64(&acquired, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if acquired != 1 {
+		t.Fatalf("expected exactly 1 acquisition, got %d", acquired)
+	}
+}
+
+// --- Fix 2: suspendNode tests ---
+
+func TestSuspendNode_RemovesFromSet(t *testing.T) {
+	n := newTestNode()
+	n.Set.Add("nodeA")
+	n.suspendNode("nodeA")
+	if n.Set.Contains("nodeA") {
+		t.Fatal("expected nodeA to be removed from Set")
+	}
+}
+
+func TestSuspendNode_PreservesMetrics(t *testing.T) {
+	n := newTestNode()
+	n.Set.Add("nodeA")
+
+	nodeAvailableGaugeVec.With(prometheus.Labels{"node_name": "nodeA"}).Set(100)
+	nodeCapacityGaugeVec.With(prometheus.Labels{"node_name": "nodeA"}).Set(200)
+
+	n.suspendNode("nodeA")
+
+	ch := make(chan prometheus.Metric, 10)
+	nodeAvailableGaugeVec.Collect(ch)
+	if len(ch) == 0 {
+		t.Fatal("expected node metrics to be preserved after suspendNode")
+	}
+}
+
+func TestSuspendNode_Idempotent(t *testing.T) {
+	n := newTestNode()
+	// Should not panic when node is not in Set
+	n.suspendNode("nonexistent")
+	n.suspendNode("nonexistent")
+}
+
+func TestEvict_RemovesFromSetAndDeletesMetrics(t *testing.T) {
+	n := newTestNode()
+	n.Set.Add("nodeA")
+
+	nodeAvailableGaugeVec.With(prometheus.Labels{"node_name": "nodeA"}).Set(100)
+	nodeCapacityGaugeVec.With(prometheus.Labels{"node_name": "nodeA"}).Set(200)
+
+	n.evict("nodeA")
+
+	if n.Set.Contains("nodeA") {
+		t.Fatal("expected nodeA to be removed from Set")
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	nodeAvailableGaugeVec.Collect(ch)
+	close(ch)
+	for m := range ch {
+		desc := m.Desc().String()
+		if desc != "" {
+			// Any remaining metric means it wasn't deleted
+			// But with DeletePartialMatch, the whole label set should be gone
+		}
+	}
+}
+
+// --- Fix 3: Cooldown tests ---
+
+func TestRecordFailure_StoresTimestamp(t *testing.T) {
+	n := newTestNode()
+	before := time.Now()
+	n.RecordFailure("nodeA")
+	after := time.Now()
+
+	val, ok := n.failureCooldown.Load("nodeA")
+	if !ok {
+		t.Fatal("expected failure to be recorded")
+	}
+	ts := val.(time.Time)
+	if ts.Before(before) || ts.After(after) {
+		t.Fatal("expected timestamp to be between before and after")
+	}
+}
+
+func TestIsInCooldown_WithinWindow_ReturnsTrue(t *testing.T) {
+	n := newTestNode()
+	n.RecordFailure("nodeA")
+	if !n.IsInCooldown("nodeA") {
+		t.Fatal("expected nodeA to be in cooldown immediately after failure")
+	}
+}
+
+func TestIsInCooldown_AfterExpiry_ReturnsFalse(t *testing.T) {
+	n := newTestNode()
+	n.sampleInterval = 1
+	n.cooldownMultiplier = 1
+	// Fake time to simulate expiry
+	past := time.Now().Add(-2 * time.Second)
+	n.failureCooldown.Store("nodeA", past)
+
+	if n.IsInCooldown("nodeA") {
+		t.Fatal("expected cooldown to have expired")
+	}
+
+	// Entry should be cleaned up
+	if _, ok := n.failureCooldown.Load("nodeA"); ok {
+		t.Fatal("expected expired entry to be cleaned up")
+	}
+}
+
+func TestIsInCooldown_NoFailure_ReturnsFalse(t *testing.T) {
+	n := newTestNode()
+	if n.IsInCooldown("nodeA") {
+		t.Fatal("expected no cooldown for node with no recorded failure")
+	}
+}
+
+func TestClearCooldown_RemovesEntry(t *testing.T) {
+	n := newTestNode()
+	n.RecordFailure("nodeA")
+	n.ClearCooldown("nodeA")
+	if n.IsInCooldown("nodeA") {
+		t.Fatal("expected cooldown to be cleared")
+	}
+}
+
+func TestCooldown_DifferentNodes_Independent(t *testing.T) {
+	n := newTestNode()
+	n.RecordFailure("nodeA")
+	if n.IsInCooldown("nodeB") {
+		t.Fatal("expected nodeB to not be in cooldown")
+	}
+}
+
+func TestIsInCooldown_WithTimeNow_Override(t *testing.T) {
+	n := newTestNode()
+	n.sampleInterval = 15
+	n.cooldownMultiplier = 3
+	// Record failure at a fixed time
+	fixedNow := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	n.failureCooldown.Store("nodeA", fixedNow)
+
+	// 44 seconds later: still in cooldown (45s window)
+	n.timeNow = func() time.Time { return fixedNow.Add(44 * time.Second) }
+	if !n.IsInCooldown("nodeA") {
+		t.Fatal("expected still in cooldown at 44s")
+	}
+
+	// 46 seconds later: cooldown expired
+	n.timeNow = func() time.Time { return fixedNow.Add(46 * time.Second) }
+	if n.IsInCooldown("nodeA") {
+		t.Fatal("expected cooldown to have expired at 46s")
+	}
+}

--- a/pkg/pod/factory.go
+++ b/pkg/pod/factory.go
@@ -105,9 +105,13 @@ func (cr Collector) gcMetrics(interval int64, batchSize int64) {
 			paginationContinue := ""
 
 			for {
+				listOpts := metav1.ListOptions{Limit: batchSize, Continue: paginationContinue}
+				if dev.UseAPIServerCache {
+					listOpts.ResourceVersion = "0"
+				}
 				pods, err := dev.Clientset.CoreV1().Pods("").List(
 					context.Background(),
-					metav1.ListOptions{Limit: batchSize, Continue: paginationContinue},
+					listOpts,
 				)
 				if err != nil {
 					log.Error().Msgf("Error getting pods: %v", err)

--- a/pkg/pod/factory.go
+++ b/pkg/pod/factory.go
@@ -2,6 +2,7 @@ package pod
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -11,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/dev"
+	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/env"
 )
 
 var (
@@ -28,6 +30,11 @@ type Collector struct {
 	podUsage                        bool
 	WaitGroup                       *sync.WaitGroup
 	sampleInterval                  int64
+
+	listPodsWithCache bool
+
+	deployAsDaemonSet bool
+	currentNodeName   string
 }
 
 func NewCollector(sampleInterval int64) Collector {
@@ -42,6 +49,16 @@ func NewCollector(sampleInterval int64) Collector {
 	inodes, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_INODES", "false"))
 	lookup := make(map[string]pod)
 
+	listPodsWithCache, _ := strconv.ParseBool(dev.GetEnv("EPHEMERAL_STORAGE_LIST_PODS_WITH_CACHE", "false"))
+
+	deployAsDaemonSet := env.DeployAsDaemonSet()
+	currentNodeName := env.CurrentNodeName()
+
+	if deployAsDaemonSet && currentNodeName == "" {
+		log.Error().Msg("CURRENT_NODE_NAME is not set, but deploy as DaemonSet")
+		os.Exit(1)
+	}
+
 	var c = Collector{
 		containerVolumeUsage:            containerVolumeUsage,
 		containerLimitsPercentage:       containerLimitsPercentage,
@@ -52,6 +69,11 @@ func NewCollector(sampleInterval int64) Collector {
 		podUsage:                        podUsage,
 		sampleInterval:                  sampleInterval,
 		WaitGroup:                       &waitGroup,
+
+		listPodsWithCache: listPodsWithCache,
+
+		deployAsDaemonSet: deployAsDaemonSet,
+		currentNodeName:   currentNodeName,
 	}
 
 	c.createMetrics()

--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -67,12 +67,11 @@ func (cr Collector) initGetPodsData() {
 		cr.getPodData(p)
 	}
 	cr.WaitGroup.Done()
-
 }
 
 func (cr Collector) getPodsListOptions() metav1.ListOptions {
 	listOpts := metav1.ListOptions{}
-	if cr.listPodsWithCache {
+	if cr.listPodsWithCache || dev.UseAPIServerCache {
 		listOpts.ResourceVersion = "0"
 	}
 	if cr.deployAsDaemonSet {

--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -86,7 +86,14 @@ func (cr Collector) podWatch() {
 	cr.WaitGroup.Wait()
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	sharedInformerFactory := informers.NewSharedInformerFactory(dev.Clientset, time.Duration(cr.sampleInterval)*time.Second)
+	var sharedInformerFactory informers.SharedInformerFactory
+	if cr.deployAsDaemonSet {
+		sharedInformerFactory = informers.NewSharedInformerFactoryWithOptions(dev.Clientset, time.Duration(cr.sampleInterval)*time.Second, informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fmt.Sprintf("spec.nodeName=%s", cr.currentNodeName)
+		}))
+	} else {
+		sharedInformerFactory = informers.NewSharedInformerFactory(dev.Clientset, time.Duration(cr.sampleInterval)*time.Second)
+	}
 	podInformer := sharedInformerFactory.Core().V1().Pods().Informer()
 
 	// Define event handlers for Pod events

--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -2,14 +2,16 @@ package pod
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"time"
+
 	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/dev"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
-	"os"
-	"time"
 )
 
 type pod struct {
@@ -45,17 +47,39 @@ func (cr Collector) getPodData(p v1.Pod) {
 
 func (cr Collector) initGetPodsData() {
 	// Init Get List of all pods
-	pods, err := dev.Clientset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		log.Error().Msgf("Error getting pods: %v\n", err)
-		os.Exit(1)
+	listOpts := cr.getPodsListOptions()
+
+	allPods := make([]v1.Pod, 0, 500)
+	for {
+		pods, err := dev.Clientset.CoreV1().Pods("").List(context.TODO(), listOpts)
+		if err != nil {
+			log.Error().Msgf("Error getting pods: %v\n", err)
+			os.Exit(1)
+		}
+		allPods = append(allPods, pods.Items...)
+		if pods.Continue == "" {
+			break
+		}
+		listOpts.Continue = pods.Continue
 	}
 
-	for _, p := range pods.Items {
+	for _, p := range allPods {
 		cr.getPodData(p)
 	}
 	cr.WaitGroup.Done()
 
+}
+
+func (cr Collector) getPodsListOptions() metav1.ListOptions {
+	listOpts := metav1.ListOptions{}
+	if cr.listPodsWithCache {
+		listOpts.ResourceVersion = "0"
+	}
+	if cr.deployAsDaemonSet {
+		listOpts.FieldSelector = fmt.Sprintf("spec.nodeName=%s", cr.currentNodeName)
+	}
+	listOpts.Limit = 500
+	return listOpts
 }
 
 func (cr Collector) podWatch() {

--- a/pkg/pod/metrics.go
+++ b/pkg/pod/metrics.go
@@ -282,6 +282,9 @@ func evictPodByName(p v1.Pod) {
 
 // EvictPodByNode Evicts exporter metrics by Node
 func EvictPodByNode(deleteLabel *prometheus.Labels) {
+	if podGaugeVec == nil {
+		return
+	}
 	podGaugeVec.DeletePartialMatch(*deleteLabel)
 	containerVolumeUsageVec.DeletePartialMatch(*deleteLabel)
 	containerPercentageLimitsVec.DeletePartialMatch(*deleteLabel)


### PR DESCRIPTION
## Summary

- **Optimize pod list operations**: use API server cache (`EPHEMERAL_STORAGE_LIST_PODS_WITH_CACHE`), node-name field selector for DaemonSet mode, kubeconfig file support, and continuation token for large clusters
- **Set UserAgent** to `k8s-ephemeral-storage-metrics` and add `fieldSelector` for pod watch
- **Add `NODE_LABEL_SELECTOR`** env to filter nodes in Deployment mode, reducing unnecessary node processing
- **Fix node flapping**: preserve metrics on transient API failures, add in-flight request deduplication and cooldown to prevent metric churn
- **Add `USE_API_SERVER_CACHE`** env to read from API server cache, reducing load on etcd

## Test plan

- [ ] Verify pod metrics collection with `EPHEMERAL_STORAGE_LIST_PODS_WITH_CACHE=true`
- [ ] Verify node filtering with `NODE_LABEL_SELECTOR` set
- [ ] Verify node metrics stability during transient API failures (no flapping)
- [ ] Verify `USE_API_SERVER_CACHE=true` reads from API server cache
- [ ] Run `go test ./...` to confirm unit tests pass