### PR TITLE
Guard informer event handlers against unchecked type assertions

### DIFF
--- a/pkg/node/k8s.go
+++ b/pkg/node/k8s.go
@@ -113,7 +113,11 @@ func (n *Node) Watch() {
 	// Define event handlers for Pod events
 	eventHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			p := obj.(*v1.Node)
+			p, ok := obj.(*v1.Node)
+			if !ok {
+				log.Error().Msgf("nodeWatch: AddFunc got unexpected type %T", obj)
+				return
+			}
 			if checkKubeletStatus(&p.Status.Conditions) {
 				n.Set.Add(p.Name)
 				if n.scrapeFromKubelet {
@@ -122,7 +126,11 @@ func (n *Node) Watch() {
 			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			p := newObj.(*v1.Node)
+			p, ok := newObj.(*v1.Node)
+			if !ok {
+				log.Error().Msgf("nodeWatch: UpdateFunc got unexpected type %T", newObj)
+				return
+			}
 			// Add nodes back that have changed readiness status.
 			if checkKubeletStatus(&p.Status.Conditions) {
 				n.Set.Add(p.Name)

--- a/pkg/node/k8s.go
+++ b/pkg/node/k8s.go
@@ -132,7 +132,21 @@ func (n *Node) Watch() {
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			p := obj.(*v1.Node)
+			p, ok := obj.(*v1.Node)
+			if !ok {
+				// On a missed delete the informer delivers a DeletedFinalStateUnknown
+				// tombstone rather than the *v1.Node; unwrap it before use to avoid a panic.
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					log.Error().Msgf("nodeWatch: DeleteFunc got unexpected type %T", obj)
+					return
+				}
+				p, ok = tombstone.Obj.(*v1.Node)
+				if !ok {
+					log.Error().Msgf("nodeWatch: tombstone held non-Node %T", tombstone.Obj)
+					return
+				}
+			}
 			n.evict(p.Name)
 			if n.scrapeFromKubelet {
 				n.KubeletEndpoint.Delete(p.Name)

--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -106,7 +106,21 @@ func (cr Collector) podWatch() {
 			cr.getPodData(*p)
 		},
 		DeleteFunc: func(obj interface{}) {
-			p := obj.(*v1.Pod)
+			p, ok := obj.(*v1.Pod)
+			if !ok {
+				// On a missed delete the informer delivers a DeletedFinalStateUnknown
+				// tombstone rather than the *v1.Pod; unwrap it before use to avoid a panic.
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					log.Error().Msgf("podWatch: DeleteFunc got unexpected type %T", obj)
+					return
+				}
+				p, ok = tombstone.Obj.(*v1.Pod)
+				if !ok {
+					log.Error().Msgf("podWatch: tombstone held non-Pod %T", tombstone.Obj)
+					return
+				}
+			}
 			cr.lookupMutex.Lock()
 			delete(*cr.lookup, p.Name)
 			cr.lookupMutex.Unlock()

--- a/pkg/pod/k8s.go
+++ b/pkg/pod/k8s.go
@@ -102,7 +102,11 @@ func (cr Collector) podWatch() {
 	// Define event handlers for Pod events
 	eventHandler := cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			p := newObj.(*v1.Pod)
+			p, ok := newObj.(*v1.Pod)
+			if !ok {
+				log.Error().Msgf("podWatch: UpdateFunc got unexpected type %T", newObj)
+				return
+			}
 			cr.getPodData(*p)
 		},
 		DeleteFunc: func(obj interface{}) {


### PR DESCRIPTION
## Problem

The pod and node informer `DeleteFunc` handlers did an unchecked
`obj.(*v1.Pod)` / `obj.(*v1.Node)` assertion. When the informer misses a
delete (watch lapse or resync under API server pressure), client-go
delivers a `cache.DeletedFinalStateUnknown` tombstone instead of the
typed object, so the assertion panics and crashes the exporter. This is
common on large clusters with high pod/node churn.

## Fix

- **DeleteFunc** (pod + node): unwrap the `DeletedFinalStateUnknown`
  tombstone (`.Obj`) before use, per the standard client-go pattern.
  Log and return on genuinely unexpected types.
- **UpdateFunc** (pod + node) and **AddFunc** (node): add a defensive
  type-assertion guard with a logged error + early return. Per the
  client-go contract these handlers never receive tombstones, but the
  guard keeps all event handlers consistent and fails loudly if the
  contract is ever violated.

## Verification

- `go build ./...`, `go vet ./...` pass
- Unit tests pass (9 in pkg/node + pkg/pod)
- No behavior change on the happy path; only panics are converted to
  logged errors