### PR TITLE
fix: improve readiness-probe reliability and harden getMetrics()

### DIFF
--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -81,7 +81,7 @@ spec:
           readinessProbe:
             failureThreshold: 10
             httpGet:
-              path: /metrics
+              path: /health
               port: {{ .Values.metrics.port  }}
               scheme: HTTP
             periodSeconds: 10

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -47,7 +47,6 @@ type ephemeralStorageMetrics struct {
 }
 
 func setMetrics(nodeName string) {
-
 	var data ephemeralStorageMetrics
 
 	start := time.Now()
@@ -78,19 +77,32 @@ func setMetrics(nodeName string) {
 		Pod.SetMetrics(podName, podNamespace, nodeName, usedBytes, availableBytes, capacityBytes, inodes, inodesFree, inodesUsed, p.Volumes)
 	}
 
-	adjustTime := sampleIntervalMill - time.Now().Sub(start).Milliseconds()
+	adjustTime := sampleIntervalMill - time.Since(start).Milliseconds()
 	if adjustTime <= 0.0 {
 		log.Error().Msgf("Node %s: Polling Rate could not keep up. Adjust your Interval to a higher number than %d seconds", nodeName, sampleInterval)
 	}
 	if Node.AdjustedPollingRate {
 		node.AdjustedPollingRateGaugeVec.With(prometheus.Labels{"node_name": nodeName}).Set(float64(adjustTime))
 	}
-
 }
 
 func getMetrics() {
+	// Wait for pod initialization with a timeout to prevent deadlock
+	// If initialization takes too long, log a warning and continue anyway
+	initTimeout := time.Duration(sampleInterval*2) * time.Second
+	initDone := make(chan struct{})
 
-	Pod.WaitGroup.Wait()
+	go func() {
+		Pod.WaitGroup.Wait()
+		close(initDone)
+	}()
+
+	select {
+	case <-initDone:
+		log.Info().Msg("Pod initialization completed successfully")
+	case <-time.After(initTimeout):
+		log.Warn().Msgf("Pod initialization timed out after %v, continuing anyway. Metrics may be incomplete.", initTimeout)
+	}
 
 	p, _ := ants.NewPoolWithFunc(Node.MaxNodeQueryConcurrency, func(node interface{}) {
 		setMetrics(node.(string))
@@ -117,6 +129,8 @@ func main() {
 	pprofEnabled, _ := strconv.ParseBool(dev.GetEnv("PPROF", "false"))
 	sampleInterval, _ = strconv.ParseInt(dev.GetEnv("SCRAPE_INTERVAL", "15"), 10, 64)
 	sampleIntervalMill = sampleInterval * 1000
+	readinessTimeoutSeconds, _ := strconv.Atoi(dev.GetEnv("READINESS_PROBE_TIMEOUT_SECONDS", "2"))
+	readinessTimeout := time.Duration(readinessTimeoutSeconds) * time.Second
 
 	dev.SetLogger()
 	dev.SetK8sClient()
@@ -127,7 +141,34 @@ func main() {
 		go dev.EnablePprof()
 	}
 	go getMetrics()
-	http.Handle("/metrics", promhttp.Handler())
+
+	// Health check endpoint for readiness probe - responds immediately
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("OK")); err != nil {
+			log.Error().Err(err).Msg("Failed to write health check response")
+		}
+	})
+
+	// Metrics endpoint with timing middleware to diagnose slow responses
+	metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		promhttp.Handler().ServeHTTP(w, r)
+		duration := time.Since(start)
+
+		if duration > readinessTimeout {
+			log.Warn().
+				Dur("duration", duration).
+				Dur("timeout", readinessTimeout).
+				Msg("Metrics endpoint took longer than readiness probe timeout")
+		} else if duration > readinessTimeout/2 {
+			log.Info().
+				Dur("duration", duration).
+				Dur("timeout", readinessTimeout).
+				Msg("Metrics endpoint response time approaching timeout")
+		}
+	})
+	http.Handle("/metrics", metricsHandler)
 	log.Info().Msg(fmt.Sprintf("Starting server listening on :%s", port))
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%s", port),

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -129,7 +129,7 @@ func main() {
 	pprofEnabled, _ := strconv.ParseBool(dev.GetEnv("PPROF", "false"))
 	sampleInterval, _ = strconv.ParseInt(dev.GetEnv("SCRAPE_INTERVAL", "15"), 10, 64)
 	sampleIntervalMill = sampleInterval * 1000
-	readinessTimeoutSeconds, _ := strconv.Atoi(dev.GetEnv("READINESS_PROBE_TIMEOUT_SECONDS", "2"))
+	readinessTimeoutSeconds, _ := strconv.Atoi(dev.GetEnv("READINESS_PROBE_TIMEOUT_SECONDS", "1"))
 	readinessTimeout := time.Duration(readinessTimeoutSeconds) * time.Second
 
 	dev.SetLogger()

--- a/pkg/pod/metrics.go
+++ b/pkg/pod/metrics.go
@@ -3,6 +3,7 @@ package pod
 import (
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
@@ -266,6 +267,7 @@ func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName str
 
 // Evicts exporter metrics by pod and container name
 func evictPodByName(p v1.Pod) {
+	start := time.Now()
 	podGaugeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 	inodesGaugeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 	inodesFreeGaugeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
@@ -277,6 +279,13 @@ func evictPodByName(p v1.Pod) {
 		containerVolumeUsageVec.DeletePartialMatch(prometheus.Labels{"container": c.Name})
 		containerPercentageLimitsVec.DeletePartialMatch(prometheus.Labels{"container": c.Name})
 		containerPercentageVolumeLimitsVec.DeletePartialMatch(prometheus.Labels{"container": c.Name})
+	}
+	duration := time.Since(start)
+	if duration > 100*time.Millisecond {
+		log.Warn().
+			Str("pod", fmt.Sprintf("%s/%s", p.Namespace, p.Name)).
+			Dur("duration", duration).
+			Msg("Pod metrics eviction took longer than 100ms")
 	}
 }
 


### PR DESCRIPTION
Readiness probes hit `/metrics`, which can exceed the probe timeout while a large metric payload is rendered under CPU limits, causing pods to flap or sit NotReady (observed in practice as readiness `context deadline exceeded` against `/metrics`).

- Add a lightweight `/health` endpoint that responds immediately, and point the chart's `readinessProbe` at it so readiness no longer depends on a full `/metrics` scrape
- Add a timeout around `Pod.WaitGroup.Wait()` in `getMetrics()` to defensively prevent a startup deadlock if pod initialization never completes
- Log when the `/metrics` handler exceeds the readiness timeout (`READINESS_PROBE_TIMEOUT_SECONDS`, default `1s` to match the chart's `readinessProbe.timeoutSeconds`) and when pod metric eviction takes longer than 100ms
- Use `time.Since()` and add error handling on the health-check response write

`livenessProbe` intentionally stays on `/metrics` (so the pod is restarted if metric collection is truly wedged); only `readinessProbe` moves to `/health`.

### Testing
- `go build`, `go vet`, `gofmt`, `helm template` (k8s 1.28–1.35): pass
- Deployed to a local single-node cluster: pod goes `1/1 Ready`; `/health` → `200 OK` (~27ms); `/metrics` → `200` with expected `ephemeral_storage_*` series; startup logs show the `getMetrics()` timeout path completing cleanly, no hangs or panics

Independent of #167 (that PR makes probe *settings* configurable; this one adds the endpoint and repoints readiness). The two touch different lines and merge cleanly in either order.