### PR TITLE
feat(chart): make liveness/readiness probe paths configurable

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -57,15 +57,17 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | pod_labels | object | `{}` | Set additional labels for the Pods |
 | pprof | bool | `false` | Enable Pprof |
 | priorityClassName | string | `nil` |  |
-| probes | object | `{"liveness":{"failureThreshold":10,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":30},"readiness":{"failureThreshold":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}}` | Liveness and Readiness probe configuration |
-| probes.liveness | object | `{"failureThreshold":10,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":30}` | Liveness probe configuration |
+| probes | object | `{"liveness":{"failureThreshold":10,"initialDelaySeconds":10,"path":"/metrics","periodSeconds":10,"successThreshold":1,"timeoutSeconds":30},"readiness":{"failureThreshold":10,"path":"/health","periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}}` | Liveness and Readiness probe configuration |
+| probes.liveness | object | `{"failureThreshold":10,"initialDelaySeconds":10,"path":"/metrics","periodSeconds":10,"successThreshold":1,"timeoutSeconds":30}` | Liveness probe configuration |
 | probes.liveness.failureThreshold | int | `10` | Number of consecutive failures required to consider the container as not ready |
 | probes.liveness.initialDelaySeconds | int | `10` | Delay before the first probe is initiated |
+| probes.liveness.path | string | `"/metrics"` | HTTP path used by the liveness probe |
 | probes.liveness.periodSeconds | int | `10` | How often to perform the probe |
 | probes.liveness.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | probes.liveness.timeoutSeconds | int | `30` | Number of seconds after which the probe times out |
-| probes.readiness | object | `{"failureThreshold":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe configuration |
+| probes.readiness | object | `{"failureThreshold":10,"path":"/health","periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe configuration |
 | probes.readiness.failureThreshold | int | `10` | Number of consecutive failures required to consider the container as not ready |
+| probes.readiness.path | string | `"/health"` | HTTP path used by the readiness probe |
 | probes.readiness.periodSeconds | int | `10` | How often to perform the probe |
 | probes.readiness.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | probes.readiness.timeoutSeconds | int | `1` | Number of seconds after which the probe times out |

--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -71,7 +71,7 @@ spec:
           livenessProbe:
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             httpGet:
-              path: /metrics
+              path: {{ .Values.probes.liveness.path }}
               port: {{ .Values.metrics.port  }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
@@ -81,7 +81,7 @@ spec:
           readinessProbe:
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
             httpGet:
-              path: /health
+              path: {{ .Values.probes.readiness.path }}
               port: {{ .Values.metrics.port  }}
               scheme: HTTP
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -165,6 +165,8 @@ containerSecurityContext:
 probes:
   # -- Liveness probe configuration
   liveness:
+    # -- HTTP path used by the liveness probe
+    path: /metrics
     # -- Number of consecutive failures required to consider the container as not ready
     failureThreshold: 10
     # -- Delay before the first probe is initiated
@@ -177,6 +179,8 @@ probes:
     timeoutSeconds: 30
   # -- Readiness probe configuration
   readiness:
+    # -- HTTP path used by the readiness probe
+    path: /health
     # -- Number of consecutive failures required to consider the container as not ready
     failureThreshold: 10
     # -- How often to perform the probe


### PR DESCRIPTION
## Summary

Makes the liveness/readiness probe `httpGet.path` configurable via chart values instead of hardcoding them in `chart/templates/DeployType.yaml`.

- Adds `probes.liveness.path` and `probes.readiness.path`.
- Defaults are unchanged (`liveness=/metrics`, `readiness=/health`), so this is **purely additive and non-breaking**.
- Regenerated `chart/README.md` via `helm-docs`.

Closes #189.

## Why

Operators sometimes need to point the probes at a different endpoint for their environment (e.g. swap which endpoint backs liveness vs readiness) without patching the chart template. See #189 for the broader discussion about whether the shipped defaults should change; this PR intentionally keeps existing defaults and only adds the knobs.

## Test plan

- [x] `helm template` renders the default paths unchanged (`livenessProbe -> /metrics`, `readinessProbe -> /health`).
- [x] Overriding `probes.liveness.path` / `probes.readiness.path` renders the provided paths.
- [x] `helm-docs` regenerated; values table includes the new keys.

Made with [Cursor](https://cursor.com)