### PR TITLE
fix: replace GC loops with scrape-driven eviction

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | list_pods_with_cache | bool | `false` | Use Kubernetes api server cache for pod list requests (reduces api server pressure at scale) |
 | log_level | string | `"info"` |  |
 | max_node_concurrency | int | `10` | Max number of concurrent query requests to the kubernetes API. |
-| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_container_logs_usage":true,"ephemeral_storage_container_rootfs_usage":true,"ephemeral_storage_container_volume_limit_percentage":true,"ephemeral_storage_container_volume_usage":true,"ephemeral_storage_inodes":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true,"gc_batch_size":500,"gc_enabled":false,"gc_interval":5,"port":9100}` | Set metrics you want to enable |
+| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_container_logs_usage":true,"ephemeral_storage_container_rootfs_usage":true,"ephemeral_storage_container_volume_limit_percentage":true,"ephemeral_storage_container_volume_usage":true,"ephemeral_storage_inodes":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true,"port":9100,"scrape_miss_tolerance":2}` | Set metrics you want to enable |
 | metrics.adjusted_polling_rate | bool | `false` | Create the ephemeral_storage_adjusted_polling_rate metrics to report Adjusted Poll Rate in milliseconds. Typically used for testing. |
 | metrics.ephemeral_storage_container_limit_percentage | bool | `true` | Percentage of ephemeral storage used by a container in a pod |
 | metrics.ephemeral_storage_container_logs_usage | bool | `true` | Current logs bytes used/available/capacity for a container in a pod |
@@ -88,10 +88,8 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | metrics.ephemeral_storage_node_capacity | bool | `true` | Capacity of ephemeral storage for a node |
 | metrics.ephemeral_storage_node_percentage | bool | `true` | Percentage of ephemeral storage used on a node |
 | metrics.ephemeral_storage_pod_usage | bool | `true` | Current ephemeral byte usage of pod |
-| metrics.gc_batch_size | int | `500` | The amount of resource to fetch from kubernetes at once when performing garbage collection |
-| metrics.gc_enabled | bool | `false` | Enable garbage collection for metrics |
-| metrics.gc_interval | int | `5` | The interval, in minutes, to perform garbage collection |
 | metrics.port | int | `9100` | Adjust the metric port as needed (default 9100) |
+| metrics.scrape_miss_tolerance | int | `2` | Number of consecutive scrapes a pod can be missing from the stats summary before its metrics are evicted |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` |  |
 | node_label_selector | string | `""` | Label selector to filter watched nodes in Deployment mode (e.g. type=virtual-kubelet) |
@@ -101,15 +99,17 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | pod_labels | object | `{}` | Set additional labels for the Pods |
 | pprof | bool | `false` | Enable Pprof |
 | priorityClassName | string | `nil` |  |
-| probes | object | `{"liveness":{"failureThreshold":10,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":30},"readiness":{"failureThreshold":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}}` | Liveness and Readiness probe configuration |
-| probes.liveness | object | `{"failureThreshold":10,"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":30}` | Liveness probe configuration |
+| probes | object | `{"liveness":{"failureThreshold":10,"initialDelaySeconds":10,"path":"/metrics","periodSeconds":10,"successThreshold":1,"timeoutSeconds":30},"readiness":{"failureThreshold":10,"path":"/health","periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}}` | Liveness and Readiness probe configuration |
+| probes.liveness | object | `{"failureThreshold":10,"initialDelaySeconds":10,"path":"/metrics","periodSeconds":10,"successThreshold":1,"timeoutSeconds":30}` | Liveness probe configuration |
 | probes.liveness.failureThreshold | int | `10` | Number of consecutive failures required to consider the container as not ready |
 | probes.liveness.initialDelaySeconds | int | `10` | Delay before the first probe is initiated |
+| probes.liveness.path | string | `"/metrics"` | HTTP path used by the liveness probe |
 | probes.liveness.periodSeconds | int | `10` | How often to perform the probe |
 | probes.liveness.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | probes.liveness.timeoutSeconds | int | `30` | Number of seconds after which the probe times out |
-| probes.readiness | object | `{"failureThreshold":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe configuration |
+| probes.readiness | object | `{"failureThreshold":10,"path":"/health","periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Readiness probe configuration |
 | probes.readiness.failureThreshold | int | `10` | Number of consecutive failures required to consider the container as not ready |
+| probes.readiness.path | string | `"/health"` | HTTP path used by the readiness probe |
 | probes.readiness.periodSeconds | int | `10` | How often to perform the probe |
 | probes.readiness.successThreshold | int | `1` | Minimum consecutive successes for the probe to be considered successful after having failed |
 | probes.readiness.timeoutSeconds | int | `1` | Number of seconds after which the probe times out |

--- a/chart/README.md
+++ b/chart/README.md
@@ -32,7 +32,7 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | list_pods_with_cache | bool | `false` | Use Kubernetes api server cache for pod list requests (reduces api server pressure at scale) |
 | log_level | string | `"info"` |  |
 | max_node_concurrency | int | `10` | Max number of concurrent query requests to the kubernetes API. |
-| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_container_logs_usage":true,"ephemeral_storage_container_rootfs_usage":true,"ephemeral_storage_container_volume_limit_percentage":true,"ephemeral_storage_container_volume_usage":true,"ephemeral_storage_inodes":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true,"gc_batch_size":500,"gc_enabled":false,"gc_interval":5,"port":9100}` | Set metrics you want to enable |
+| metrics | object | `{"adjusted_polling_rate":false,"ephemeral_storage_container_limit_percentage":true,"ephemeral_storage_container_logs_usage":true,"ephemeral_storage_container_rootfs_usage":true,"ephemeral_storage_container_volume_limit_percentage":true,"ephemeral_storage_container_volume_usage":true,"ephemeral_storage_inodes":true,"ephemeral_storage_node_available":true,"ephemeral_storage_node_capacity":true,"ephemeral_storage_node_percentage":true,"ephemeral_storage_pod_usage":true,"port":9100,"scrape_miss_tolerance":2}` | Set metrics you want to enable |
 | metrics.adjusted_polling_rate | bool | `false` | Create the ephemeral_storage_adjusted_polling_rate metrics to report Adjusted Poll Rate in milliseconds. Typically used for testing. |
 | metrics.ephemeral_storage_container_limit_percentage | bool | `true` | Percentage of ephemeral storage used by a container in a pod |
 | metrics.ephemeral_storage_container_logs_usage | bool | `true` | Current logs bytes used/available/capacity for a container in a pod |
@@ -44,10 +44,8 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | metrics.ephemeral_storage_node_capacity | bool | `true` | Capacity of ephemeral storage for a node |
 | metrics.ephemeral_storage_node_percentage | bool | `true` | Percentage of ephemeral storage used on a node |
 | metrics.ephemeral_storage_pod_usage | bool | `true` | Current ephemeral byte usage of pod |
-| metrics.gc_batch_size | int | `500` | The amount of resource to fetch from kubernetes at once when performing garbage collection |
-| metrics.gc_enabled | bool | `false` | Enable garbage collection for metrics |
-| metrics.gc_interval | int | `5` | The interval, in minutes, to perform garbage collection |
 | metrics.port | int | `9100` | Adjust the metric port as needed (default 9100) |
+| metrics.scrape_miss_tolerance | int | `2` | Number of consecutive scrapes a pod can be missing from the stats summary before its metrics are evicted |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` |  |
 | node_label_selector | string | `""` | Label selector to filter watched nodes in Deployment mode (e.g. type=virtual-kubelet) |

--- a/chart/templates/DeployType.yaml
+++ b/chart/templates/DeployType.yaml
@@ -176,17 +176,9 @@ spec:
             - name: PPROF
               value: "{{ .Values.pprof }}"
               {{- end }}
-              {{- if .Values.metrics.gc_enabled }}
-            - name: GC_ENABLED
-              value: "{{ .Values.metrics.gc_enabled }}"
-              {{- end }}
-              {{- if .Values.metrics.gc_interval }}
-            - name: GC_INTERVAL
-              value: "{{ .Values.metrics.gc_interval }}"
-              {{- end }}
-              {{- if .Values.metrics.gc_batch_size }}
-            - name: GC_BATCH_SIZE
-              value: "{{ .Values.metrics.gc_batch_size }}"
+              {{- if .Values.metrics.scrape_miss_tolerance }}
+            - name: SCRAPE_MISS_TOLERANCE
+              value: "{{ .Values.metrics.scrape_miss_tolerance }}"
               {{- end }}
               {{- if eq .Values.deploy_type  "DaemonSet" }}
             - name: CURRENT_NODE_NAME

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -55,12 +55,8 @@ metrics:
   ephemeral_storage_node_percentage: true
   # -- Create the ephemeral_storage_adjusted_polling_rate metrics to report Adjusted Poll Rate in milliseconds. Typically used for testing.
   adjusted_polling_rate: false
-  # -- Enable garbage collection for metrics
-  gc_enabled: false
-  # -- The interval, in minutes, to perform garbage collection
-  gc_interval: 5
-  # -- The amount of resource to fetch from kubernetes at once when performing garbage collection
-  gc_batch_size: 500
+  # -- Number of consecutive scrapes a pod can be missing from the stats summary before its metrics are evicted
+  scrape_miss_tolerance: 2
 
 log_level: info
 # -- Set as Deployment for single controller to query all nodes or Daemonset

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -61,6 +61,13 @@ func setMetrics(nodeName string) {
 	log.Debug().Msg(fmt.Sprintf("Fetched proxy stats from node : %s", nodeName))
 	_ = json.Unmarshal(content, &data)
 
+	// Evict pods absent from the stats summary for scrapeMissTolerance consecutive scrapes
+	currentPods := make([]string, 0, len(data.Pods))
+	for _, p := range data.Pods {
+		currentPods = append(currentPods, p.PodRef.Name)
+	}
+	pod.EvictStalePods(nodeName, currentPods)
+
 	for _, p := range data.Pods {
 		podName := p.PodRef.Name
 		podNamespace := p.PodRef.Namespace

--- a/pkg/node/factory.go
+++ b/pkg/node/factory.go
@@ -1,16 +1,13 @@
 package node
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"sync"
-	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/rs/zerolog/log"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/dev"
 )
@@ -71,13 +68,6 @@ func NewCollector(sampleInterval int64) Node {
 	}
 	node.createMetrics()
 
-	gcEnabled, _ := strconv.ParseBool(dev.GetEnv("GC_ENABLED", "false"))
-	gcInterval, _ := strconv.ParseInt(dev.GetEnv("GC_INTERVAL", "5"), 10, 64)
-	gcBatchSize, _ := strconv.ParseInt(dev.GetEnv("GC_BATCH_SIZE", "500"), 10, 64)
-	if gcEnabled {
-		go node.gcMetrics(gcInterval, gcBatchSize)
-	}
-
 	if node.deployType != "Deployment" {
 		node.Set.Add(dev.GetEnv("CURRENT_NODE_NAME", ""))
 	} else {
@@ -85,58 +75,4 @@ func NewCollector(sampleInterval int64) Node {
 	}
 
 	return node
-}
-
-func (n Node) gcMetrics(interval int64, batchSize int64) {
-	ticker := time.NewTicker(time.Duration(interval) * time.Minute)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			log.Info().Msgf("Starting GC for nodes in batches of %d", batchSize)
-			currentNodes := make(map[string]struct{})
-			paginationContinue := ""
-
-			for {
-				nodes, err := dev.Clientset.CoreV1().Nodes().List(
-					context.Background(),
-					metav1.ListOptions{
-						Limit:         batchSize,
-						Continue:      paginationContinue,
-						LabelSelector: n.nodeLabelSelector,
-					},
-				)
-				if err != nil {
-					log.Error().Msgf("Error getting nodes: %v", err)
-					continue
-				}
-
-				// Collect pod names from this batch
-				for _, n := range nodes.Items {
-					currentNodes[n.Name] = struct{}{}
-				}
-
-				if nodes.Continue != "" {
-					paginationContinue = nodes.Continue
-				} else {
-					// All batches processed
-					break
-				}
-			}
-			log.Info().Msgf("Found %d current nodes in cluster", len(currentNodes))
-
-			// Identify all nodes we have metrics for that no longer exist
-			for nodeName := range n.Set.Iter() {
-				if _, ok := currentNodes[nodeName]; !ok {
-					log.Info().Msgf("Garbage collector removing metrics for deleted node %s", nodeName)
-					n.evict(nodeName)
-					if n.scrapeFromKubelet {
-						n.KubeletEndpoint.Delete(nodeName)
-					}
-				}
-			}
-
-			log.Info().Msgf("Node GC cycle completed")
-		}
-	}
 }

--- a/pkg/pod/factory.go
+++ b/pkg/pod/factory.go
@@ -1,15 +1,11 @@
 package pod
 
 import (
-	"context"
 	"os"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/rs/zerolog/log"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/dev"
 )
@@ -83,12 +79,11 @@ func NewCollector(sampleInterval int64) Collector {
 
 	c.createMetrics()
 
-	gcEnabled, _ := strconv.ParseBool(dev.GetEnv("GC_ENABLED", "false"))
-	gcInterval, _ := strconv.ParseInt(dev.GetEnv("GC_INTERVAL", "5"), 10, 64)
-	gcBatchSize, _ := strconv.ParseInt(dev.GetEnv("GC_BATCH_SIZE", "500"), 10, 64)
-	if gcEnabled {
-		go c.gcMetrics(gcInterval, gcBatchSize)
+	tolerance, _ := strconv.Atoi(dev.GetEnv("SCRAPE_MISS_TOLERANCE", "2"))
+	if tolerance < 1 {
+		tolerance = 2
 	}
+	scrapeMissTolerance = tolerance
 
 	if containerLimitsPercentage || containerVolumeLimitsPercentage {
 		waitGroup.Add(1)
@@ -97,70 +92,4 @@ func NewCollector(sampleInterval int64) Collector {
 	}
 
 	return c
-}
-
-func (cr Collector) gcMetrics(interval int64, batchSize int64) {
-	ticker := time.NewTicker(time.Duration(interval) * time.Minute)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			log.Info().Msgf("Starting GC for pods in batches of %d", batchSize)
-			currentPods := make(map[string]struct{})
-			paginationContinue := ""
-
-			for {
-				pods, err := dev.Clientset.CoreV1().Pods("").List(
-					context.Background(),
-					metav1.ListOptions{Limit: batchSize, Continue: paginationContinue},
-				)
-				if err != nil {
-					log.Error().Msgf("Error getting pods: %v", err)
-					// Exit this GC cycle on error
-					break
-				}
-
-				// Collect pod names from this batch
-				for _, p := range pods.Items {
-					currentPods[p.Name] = struct{}{}
-				}
-
-				if pods.Continue != "" {
-					paginationContinue = pods.Continue
-				} else {
-					// All batches processed
-					break
-				}
-			}
-			log.Info().Msgf("Found %d current pods in cluster", len(currentPods))
-
-			deletedPods := make(map[string]struct{})
-			cr.lookupMutex.RLock()
-			for podName := range *cr.lookup {
-				if _, exists := currentPods[podName]; !exists {
-					deletedPods[podName] = struct{}{}
-				}
-			}
-			cr.lookupMutex.RUnlock()
-			log.Info().Msgf("Found %d deleted pods to clean up", len(deletedPods))
-
-			if len(deletedPods) > 0 {
-				cr.lookupMutex.Lock()
-				for podName := range deletedPods {
-					log.Info().Msgf("Garbage collector removing metrics for deleted pod %s", podName)
-					delete(*cr.lookup, podName)
-					evictPodByName(
-						v1.Pod{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: podName,
-							},
-						},
-					)
-				}
-				cr.lookupMutex.Unlock()
-			}
-
-			log.Info().Msgf("Pod GC cycle completed")
-		}
-	}
 }

--- a/pkg/pod/metrics.go
+++ b/pkg/pod/metrics.go
@@ -3,11 +3,13 @@ package pod
 import (
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -32,7 +34,25 @@ var (
 	inodesGaugeVec                     *prometheus.GaugeVec
 	inodesFreeGaugeVec                 *prometheus.GaugeVec
 	inodesUsedGaugeVec                 *prometheus.GaugeVec
+
+	// nodeTrackers holds per-node scrape-driven eviction state.
+	// Keyed by nodeName; value is *podTracker.
+	nodeTrackers sync.Map
+
+	// scrapeMissTolerance is the number of consecutive scrapes a pod
+	// can be missing from the stats summary before its metrics are evicted.
+	// Set in NewCollector from the SCRAPE_MISS_TOLERANCE env var.
+	scrapeMissTolerance int
 )
+
+// podTracker tracks which pods were seen on a node across scrapes.
+// On each scrape, pods present in the stats summary reset their miss count
+// to 0. Pods absent from the stats summary increment their miss count; when
+// it reaches scrapeMissTolerance, the pod's metrics are evicted.
+type podTracker struct {
+	mu       sync.Mutex
+	lastSeen map[string]int
+}
 
 type FsStats struct {
 	AvailableBytes int64 `json:"availableBytes"`
@@ -396,13 +416,9 @@ func (cr Collector) createMetrics() {
 func (cr Collector) SetMetrics(podName string, podNamespace string, nodeName string, usedBytes float64, availableBytes float64, capacityBytes float64, inodes float64, inodesFree float64, inodesUsed float64, volumes []Volume, containers []ContainerStats) {
 
 	var setValue float64
-	cr.lookupMutex.Lock()
+	cr.lookupMutex.RLock()
 	podResult, okPodResult := (*cr.lookup)[podName]
-	if !okPodResult {
-		// To ensure we can garbage collect pod metrics we need to make sure all are stored in lookup
-		(*cr.lookup)[podName] = pod{}
-	}
-	cr.lookupMutex.Unlock()
+	cr.lookupMutex.RUnlock()
 
 	// TODO: something seems wrong about the metrics.
 	//		the volume capacityBytes is not reflected in this query
@@ -558,13 +574,9 @@ func evictPodByName(p v1.Pod) {
 	containerLogsInodesFreeVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 	containerLogsInodesUsedVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 
-	// TODO: Look into removing this for loop and delete by pod_name
-	// e.g. containerVolumeUsageVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
-	for _, c := range p.Spec.Containers {
-		containerVolumeUsageVec.DeletePartialMatch(prometheus.Labels{"container": c.Name})
-		containerPercentageLimitsVec.DeletePartialMatch(prometheus.Labels{"container": c.Name})
-		containerPercentageVolumeLimitsVec.DeletePartialMatch(prometheus.Labels{"container": c.Name})
-	}
+	containerVolumeUsageVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerPercentageLimitsVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
+	containerPercentageVolumeLimitsVec.DeletePartialMatch(prometheus.Labels{"pod_name": p.Name})
 	duration := time.Since(start)
 	if duration > 100*time.Millisecond {
 		log.Warn().
@@ -576,6 +588,9 @@ func evictPodByName(p v1.Pod) {
 
 // EvictPodByNode Evicts exporter metrics by Node
 func EvictPodByNode(deleteLabel *prometheus.Labels) {
+	if nodeName, ok := (*deleteLabel)["node_name"]; ok {
+		nodeTrackers.Delete(nodeName)
+	}
 	podGaugeVec.DeletePartialMatch(*deleteLabel)
 	containerVolumeUsageVec.DeletePartialMatch(*deleteLabel)
 	containerPercentageLimitsVec.DeletePartialMatch(*deleteLabel)
@@ -594,4 +609,41 @@ func EvictPodByNode(deleteLabel *prometheus.Labels) {
 	containerLogsInodesVec.DeletePartialMatch(*deleteLabel)
 	containerLogsInodesFreeVec.DeletePartialMatch(*deleteLabel)
 	containerLogsInodesUsedVec.DeletePartialMatch(*deleteLabel)
+}
+
+// EvictStalePods evicts metrics for pods on nodeName that have been absent
+// from the kubelet stats summary for scrapeMissTolerance consecutive scrapes.
+//
+// Each scrape passes the current set of pod names from the stats summary.
+// Pods present in the summary reset their miss count to 0. Pods absent
+// increment their miss count; when it reaches scrapeMissTolerance, the pod's
+// metrics are evicted and the pod is removed from the tracker.
+//
+// Query failures (node unreachable) do not call this function — the caller
+// returns early on error, so miss counts are not incremented spuriously.
+func EvictStalePods(nodeName string, currentPods []string) {
+	t, _ := nodeTrackers.LoadOrStore(nodeName, &podTracker{lastSeen: make(map[string]int)})
+	tracker := t.(*podTracker)
+
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	currentSet := make(map[string]struct{}, len(currentPods))
+	for _, name := range currentPods {
+		currentSet[name] = struct{}{}
+		tracker.lastSeen[name] = 0
+	}
+
+	for podName, misses := range tracker.lastSeen {
+		if _, exists := currentSet[podName]; !exists {
+			misses++
+			if misses >= scrapeMissTolerance {
+				log.Info().Msgf("Scrape-driven eviction: pod %s on node %s missing %d scrapes, evicting", podName, nodeName, misses)
+				evictPodByName(v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName}})
+				delete(tracker.lastSeen, podName)
+			} else {
+				tracker.lastSeen[podName] = misses
+			}
+		}
+	}
 }

--- a/pkg/pod/metrics_test.go
+++ b/pkg/pod/metrics_test.go
@@ -215,10 +215,18 @@ func TestRootfsLogsMetrics(t *testing.T) {
 	})
 
 	t.Run("eviction", func(t *testing.T) {
+		// Evict p3 (which has container volume/limit metrics from containerVolume_limits)
+		// and p1 (which has rootfs/logs metrics from set_values).
 		evictPodByName(v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "p1",
 				Namespace: "ns1",
+			},
+		})
+		evictPodByName(v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "p3",
+				Namespace: "ns3",
 			},
 		})
 
@@ -231,6 +239,9 @@ func TestRootfsLogsMetrics(t *testing.T) {
 			"ephemeral_storage_container_logs_inodes",
 			"ephemeral_storage_container_logs_inodes_free",
 			"ephemeral_storage_container_logs_inodes_used",
+			"ephemeral_storage_container_volume_usage",
+			"ephemeral_storage_container_limit_percentage",
+			"ephemeral_storage_container_volume_limit_percentage",
 		)
 		if err != nil {
 			t.Fatalf("GatherAndCount failed: %v", err)
@@ -238,5 +249,261 @@ func TestRootfsLogsMetrics(t *testing.T) {
 		if count > 0 {
 			t.Errorf("expected 0 time series after eviction, got %d", count)
 		}
+	})
+
+	t.Run("scrapeDrivenEviction", func(t *testing.T) {
+		// Set tolerance to 2 for this test
+		prev := scrapeMissTolerance
+		scrapeMissTolerance = 2
+		defer func() { scrapeMissTolerance = prev }()
+
+		// Set metrics for p4 on n4 (uses already-registered vecs from top-level createMetrics)
+		cr4 := Collector{
+			containerRootfsUsage: true,
+			lookup:               &map[string]pod{},
+			lookupMutex:          &sync.RWMutex{},
+		}
+		containers := []ContainerStats{
+			{Name: "c1", Rootfs: FsStats{UsedBytes: 100, CapacityBytes: 1000}},
+		}
+		cr4.SetMetrics("p4", "ns4", "n4", 0, 0, 0, 0, 0, 0, nil, containers)
+
+		// Scrape 1: p4 present → miss count = 0
+		EvictStalePods("n4", []string{"p4"})
+
+		// Scrape 2: p4 missing → miss count = 1 (not yet evicted)
+		EvictStalePods("n4", nil)
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 series after 1 miss, got %d", count)
+		}
+
+		// Scrape 3: p4 missing → miss count = 2 → evicted
+		EvictStalePods("n4", nil)
+
+		count, err = testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected 0 series after 2 misses (tolerance), got %d", count)
+		}
+	})
+
+	t.Run("scrapeDriven_resetOnReappearance", func(t *testing.T) {
+		// Miss count must reset when a pod reappears, not accumulate.
+		// Tolerance counts CONSECUTIVE misses only.
+		prev := scrapeMissTolerance
+		scrapeMissTolerance = 2
+		defer func() { scrapeMissTolerance = prev }()
+
+		cr5 := Collector{
+			containerRootfsUsage: true,
+			lookup:               &map[string]pod{},
+			lookupMutex:          &sync.RWMutex{},
+		}
+		containers := []ContainerStats{
+			{Name: "c1", Rootfs: FsStats{UsedBytes: 100, CapacityBytes: 1000}},
+		}
+		cr5.SetMetrics("p5", "ns5", "n5", 0, 0, 0, 0, 0, 0, nil, containers)
+
+		EvictStalePods("n5", []string{"p5"}) // miss=0
+		EvictStalePods("n5", nil)            // miss=1
+		EvictStalePods("n5", []string{"p5"}) // reset to 0
+		EvictStalePods("n5", nil)            // miss=1, NOT 2
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 series (miss count reset on reappearance), got %d", count)
+		}
+		evictPodByName(v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p5"}})
+	})
+
+	t.Run("scrapeDriven_multiplePods", func(t *testing.T) {
+		// Only absent pods get miss increments; present pods reset to 0.
+		prev := scrapeMissTolerance
+		scrapeMissTolerance = 2
+		defer func() { scrapeMissTolerance = prev }()
+
+		cr := Collector{
+			containerRootfsUsage: true,
+			lookup:               &map[string]pod{},
+			lookupMutex:          &sync.RWMutex{},
+		}
+		containers := []ContainerStats{
+			{Name: "c1", Rootfs: FsStats{UsedBytes: 100, CapacityBytes: 1000}},
+		}
+		cr.SetMetrics("p6a", "ns6", "n6", 0, 0, 0, 0, 0, 0, nil, containers)
+		cr.SetMetrics("p6b", "ns6", "n6", 0, 0, 0, 0, 0, 0, nil, containers)
+
+		EvictStalePods("n6", []string{"p6a", "p6b"}) // both miss=0
+		EvictStalePods("n6", []string{"p6a"})        // p6b miss=1
+		EvictStalePods("n6", []string{"p6a"})        // p6b miss=2 → evicted
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 (p6a survives, p6b evicted), got %d", count)
+		}
+		evictPodByName(v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p6a"}})
+	})
+
+	t.Run("scrapeDriven_nodeIsolation", func(t *testing.T) {
+		// Each node has its own tracker. Evicting on one node
+		// must not affect another node's pod.
+		prev := scrapeMissTolerance
+		scrapeMissTolerance = 2
+		defer func() { scrapeMissTolerance = prev }()
+
+		cr := Collector{
+			containerRootfsUsage: true,
+			lookup:               &map[string]pod{},
+			lookupMutex:          &sync.RWMutex{},
+		}
+		containers := []ContainerStats{
+			{Name: "c1", Rootfs: FsStats{UsedBytes: 100, CapacityBytes: 1000}},
+		}
+		cr.SetMetrics("p7", "ns7", "n7", 0, 0, 0, 0, 0, 0, nil, containers)
+		cr.SetMetrics("p8", "ns8", "n8", 0, 0, 0, 0, 0, 0, nil, containers)
+
+		EvictStalePods("n7", []string{"p7"}) // p7 tracked, miss=0
+		EvictStalePods("n7", nil)            // p7 miss=1
+		EvictStalePods("n7", nil)            // p7 miss=2 → evicted
+		EvictStalePods("n8", []string{"p8"})
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 (p8 survives on n8, p7 evicted on n7), got %d", count)
+		}
+		evictPodByName(v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p7"}})
+		evictPodByName(v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p8"}})
+	})
+
+	t.Run("scrapeDriven_evictPodByNodeClearsTracker", func(t *testing.T) {
+		// EvictPodByNode must clear the per-node tracker so
+		// subsequent EvictStalePods starts fresh.
+		prev := scrapeMissTolerance
+		scrapeMissTolerance = 2
+		defer func() { scrapeMissTolerance = prev }()
+
+		cr := Collector{
+			containerRootfsUsage: true,
+			lookup:               &map[string]pod{},
+			lookupMutex:          &sync.RWMutex{},
+		}
+		containers := []ContainerStats{
+			{Name: "c1", Rootfs: FsStats{UsedBytes: 100, CapacityBytes: 1000}},
+		}
+		cr.SetMetrics("p9", "ns9", "n9", 0, 0, 0, 0, 0, 0, nil, containers)
+		EvictStalePods("n9", []string{"p9"})
+
+		deleteLabel := prometheus.Labels{"node_name": "n9"}
+		EvictPodByNode(&deleteLabel)
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected 0 after EvictPodByNode, got %d", count)
+		}
+
+		// New pod on same node gets a fresh tracker (no leftover state).
+		cr.SetMetrics("p9b", "ns9", "n9", 0, 0, 0, 0, 0, 0, nil, containers)
+		EvictStalePods("n9", []string{"p9b"})
+		EvictStalePods("n9", nil) // 1 miss, NOT evicted (tolerance=2)
+
+		count, err = testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 (p9b fresh tracker, 1 miss not evicted), got %d", count)
+		}
+		evictPodByName(v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p9b"}})
+	})
+
+	t.Run("scrapeDriven_tolerance1", func(t *testing.T) {
+		prev := scrapeMissTolerance
+		scrapeMissTolerance = 1
+		defer func() { scrapeMissTolerance = prev }()
+
+		cr := Collector{
+			containerRootfsUsage: true,
+			lookup:               &map[string]pod{},
+			lookupMutex:          &sync.RWMutex{},
+		}
+		containers := []ContainerStats{
+			{Name: "c1", Rootfs: FsStats{UsedBytes: 100, CapacityBytes: 1000}},
+		}
+		cr.SetMetrics("p10", "ns10", "n10", 0, 0, 0, 0, 0, 0, nil, containers)
+
+		EvictStalePods("n10", []string{"p10"})
+		EvictStalePods("n10", nil) // miss=1 → evicted (tolerance=1)
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("expected 0 (tolerance=1, evicted after 1 miss), got %d", count)
+		}
+	})
+
+	t.Run("evictPodByName_crossPodSafety", func(t *testing.T) {
+		// Bug 2 fix: evicting pod A must NOT delete pod B's metrics
+		// when both share the same container name. Old code used
+		// DeletePartialMatch({"container": "c1"}) which deleted both.
+		cr := Collector{
+			containerRootfsUsage: true,
+			lookup:               &map[string]pod{},
+			lookupMutex:          &sync.RWMutex{},
+		}
+		containers := []ContainerStats{
+			{Name: "c1", Rootfs: FsStats{UsedBytes: 100, CapacityBytes: 1000}},
+		}
+		cr.SetMetrics("p11a", "ns11", "n11", 0, 0, 0, 0, 0, 0, nil, containers)
+		cr.SetMetrics("p11b", "ns11", "n11", 0, 0, 0, 0, 0, 0, nil, containers)
+
+		evictPodByName(v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p11a"}})
+
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
+			"ephemeral_storage_container_rootfs_used_bytes",
+		)
+		if err != nil {
+			t.Fatalf("GatherAndCount failed: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 (p11b survives, same container name), got %d", count)
+		}
+		evictPodByName(v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p11b"}})
 	})
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -62,8 +62,6 @@ function main() {
     "metrics.adjusted_polling_rate=true"
     "pprof=true"
     "prometheus.rules.enable=true"
-    "metrics.gc_interval=1"
-    "metrics.gc_enabled=true"
     "metrics.ephemeral_storage_container_rootfs_usage=true"
     "metrics.ephemeral_storage_container_logs_usage=true"
   )

--- a/tests/e2e/deployment_test.go
+++ b/tests/e2e/deployment_test.go
@@ -451,9 +451,9 @@ var _ = ginkgo.Describe("Test Metrics\n", func() {
 			// Delete the many-pods deployment
 			destroyManyPods()
 
-			// Wait for GC to run (gc_interval is 1 minute, add buffer for safety)
-			// GC runs every 1 minute, so wait 90 seconds to ensure it runs at least once
-			ginkgo.GinkgoWriter.Printf("\nWaiting 90 seconds for garbage collection to remove pod metrics...\n")
+			// Wait for scrape-driven eviction: at interval=5s with tolerance=2, pods are evicted after ~15s.
+			// Wait 90 seconds for safety margin.
+			ginkgo.GinkgoWriter.Printf("\nWaiting 90 seconds for scrape-driven eviction to remove pod metrics...\n")
 			time.Sleep(90 * time.Second)
 
 			// Verify metrics for many-pods namespace are removed


### PR DESCRIPTION
## Summary

Replaces the pod and node GC loops with scrape-driven eviction in the scrape loop. Also fixes the cross-pod deletion bug in `evictPodByName` and drops all GC config (`gc_enabled`, `gc_interval`, `gc_batch_size`).

## Bugs fixed

| # | Severity | Bug | Fix |
|---|---|---|---|
| 1 | Critical | GC never evicted 3 of 21 GaugeVecs (container volume/limit) because the stub pod had no containers | Removed GC loop; scrape-driven eviction + `evictPodByName` uses `pod_name` for all vecs |
| 2 | Critical | Watch eviction via `DeletePartialMatch({container: c.Name})` caused cross-pod deletion when pods shared a container name | `evictPodByName` now uses `DeletePartialMatch({pod_name: p.Name})` for all 21 vecs |
| 3 | Critical | Node GC infinite retry on API error (`continue` vs `break`) | Node GC removed |
| 4 | Significant | Pod GC listed all cluster pods in DaemonSet mode (no `spec.nodeName` fieldSelector) | Pod GC removed |
| 5 | Significant | `GC_INTERVAL=0` panicked in `time.NewTicker(0)` | GC removed |

## How it works

The scrape loop (`cmd/app/main.go:setMetrics`) now builds a list of current pod names from the kubelet stats summary and calls `pod.EvictStalePods(nodeName, currentPods)`. Each node has a per-node tracker (`podTracker{lastSeen map[string]int}`) that records consecutive misses. Pods absent for `SCRAPE_MISS_TOLERANCE` consecutive scrapes (default 2) are evicted via `evictPodByName`. Pods that reappear reset their miss count to 0.

Node cleanup was already handled by the scrape loop on query failure (`node/k8s.go:91`: `n.evict(node)`), so the node GC loop was redundant.

Query failures (node unreachable) do not increment miss counts — `setMetrics` returns early on `Node.Query` error, so `EvictStalePods` is not called.

## Config changes

- **Removed:** `gc_enabled`, `gc_interval`, `gc_batch_size` (chart values + env vars)
- **Added:** `SCRAPE_MISS_TOLERANCE` env var, `metrics.scrape_miss_tolerance` chart value (default 2)
- Pod cleanup is now always on — no toggle needed

## Test coverage

7 subtests in `pkg/pod/metrics_test.go`:
- `scrapeDrivenEviction` — basic flow (present → miss=1 → miss=2 → evicted)
- `scrapeDriven_resetOnReappearance` — miss count resets when pod reappears (consecutive, not cumulative)
- `scrapeDriven_multiplePods` — partial absence on same node
- `scrapeDriven_nodeIsolation` — per-node tracker isolation
- `scrapeDriven_evictPodByNodeClearsTracker` — tracker cleanup on node eviction
- `scrapeDriven_tolerance1` — tolerance=1 immediate eviction
- `evictPodByName_crossPodSafety` — Bug 2 fix verified

Pre-PR gate: `make fmt vet test-unit test-helm-render` — all pass. Helm renders across 8 k8s versions (1.28.0–1.35.0).

## Behavior change

Users who had `gc_enabled: false` (the default) will now get pod cleanup they didn't before. This is strictly better — stale pod metrics were a bug. Users who had `gc_enabled: true` get faster cleanup (15s vs 5min) with no API list overhead.

No metric names, labels, or types change. No existing config breaks beyond the removed GC settings (helm ignores unknown values).