### PR TITLE
fix: evict inode metrics in EvictPodByNode to stop leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ chart/k8s-ephemeral-storage-metrics-*.tgz
 .idea
 /tests/charts/observability/Chart.lock
 /tests/charts/observability/charts/
+/docs/

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,12 @@ minikube_scale_up:
 minikube_scale_down:
 	minikube node delete m02
 
+minikube_node2_stop:
+	docker stop minikube-m02
+
+minikube_node2_start:
+	docker start minikube-m02
+
 init: fmt vet gosec
 
 deploy_debug: init

--- a/pkg/pod/metrics.go
+++ b/pkg/pod/metrics.go
@@ -609,6 +609,9 @@ func EvictPodByNode(deleteLabel *prometheus.Labels) {
 	containerLogsInodesVec.DeletePartialMatch(*deleteLabel)
 	containerLogsInodesFreeVec.DeletePartialMatch(*deleteLabel)
 	containerLogsInodesUsedVec.DeletePartialMatch(*deleteLabel)
+	inodesGaugeVec.DeletePartialMatch(*deleteLabel)
+	inodesFreeGaugeVec.DeletePartialMatch(*deleteLabel)
+	inodesUsedGaugeVec.DeletePartialMatch(*deleteLabel)
 }
 
 // EvictStalePods evicts metrics for pods on nodeName that have been absent

--- a/pkg/pod/metrics_test.go
+++ b/pkg/pod/metrics_test.go
@@ -195,9 +195,6 @@ func TestRootfsLogsMetrics(t *testing.T) {
 		deleteLabel := prometheus.Labels{"node_name": "n2"}
 		EvictPodByNode(&deleteLabel)
 
-		// NOTE: EvictPodByNode does not clean pod-level inodesGaugeVec,
-		// inodesFreeGaugeVec, inodesUsedGaugeVec by node_name (known gap).
-		// podGaugeVec for p2 IS cleaned, but the 3 inode vecs are not.
 		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer,
 			"ephemeral_storage_pod_usage",
 			"ephemeral_storage_inodes",
@@ -207,10 +204,10 @@ func TestRootfsLogsMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GatherAndCount failed: %v", err)
 		}
-		// 3 remaining (inodes/inodesFree/inodesUsed for p1,n1 from set_values)
-		// + potentially 3 from p2,n2 if not cleaned by EvictPodByNode
-		if count != 6 {
-			t.Errorf("expected 6 (p1+n1 in 3 vecs + p2+n2 in 3 vecs), got %d", count)
+		// Expect 3: inodes/inodesFree/inodesUsed for p1,n1 (from set_values).
+		// p2,n2 inode series should be cleaned by EvictPodByNode.
+		if count != 3 {
+			t.Errorf("expected 3 (p1,n1 only), got %d — EvictPodByNode likely leaked inode metrics", count)
 		}
 	})
 

--- a/tests/e2e/deployment_test.go
+++ b/tests/e2e/deployment_test.go
@@ -122,12 +122,22 @@ func checkPrometheus(checkSlice []string, inverse bool) {
 func WatchContainerPercentage() {
 	status := 0
 	re := regexp.MustCompile(`ephemeral_storage_container_limit_percentage{container="grow-test",node_name="minikube".+,pod_namespace="ephemeral-metrics",source="container"}\s+(.+)`)
-	output := requestPrometheusString()
-	match := re.FindAllStringSubmatch(output, -1)
-	gomega.Expect(match).ShouldNot(gomega.BeEmpty())
-	floatValue, _ := strconv.ParseFloat(match[0][1], 64)
-	if floatValue < 100.0 {
-		status = 1
+	timeout := time.Second * 180
+	startTime := time.Now()
+	for {
+		if time.Since(startTime) >= timeout {
+			break
+		}
+		output := requestPrometheusString()
+		match := re.FindAllStringSubmatch(output, -1)
+		if match != nil {
+			floatValue, _ := strconv.ParseFloat(match[0][1], 64)
+			if floatValue < 100.0 {
+				status = 1
+				break
+			}
+		}
+		time.Sleep(time.Second)
 	}
 	gomega.Expect(status).Should(gomega.Equal(1))
 
@@ -135,24 +145,23 @@ func WatchContainerPercentage() {
 
 func WatchContainerVolumePercentage() {
 	status := 0
+	re := regexp.MustCompile(`ephemeral_storage_container_volume_limit_percentage{container="shrink-test",mount_path="\/cache".+volume_name="cache-volume-1"}\s+(.+)`)
 	timeout := time.Second * 180
 	startTime := time.Now()
 	for {
-		elapsed := time.Since(startTime)
-		if elapsed >= timeout {
+		if time.Since(startTime) >= timeout {
 			break
 		}
-		re := regexp.MustCompile(`ephemeral_storage_container_volume_limit_percentage{container="shrink-test",mount_path="\/cache".+volume_name="cache-volume-1"}\s+(.+)`)
 		output := requestPrometheusString()
 		match := re.FindAllStringSubmatch(output, -1)
-		if match == nil {
-			continue
+		if match != nil {
+			floatValue, _ := strconv.ParseFloat(match[0][1], 64)
+			if floatValue < 100.0 {
+				status = 1
+				break
+			}
 		}
-		floatValue, _ := strconv.ParseFloat(match[0][1], 64)
-		if floatValue < 100.0 {
-			status = 1
-			break
-		}
+		time.Sleep(time.Second)
 	}
 	gomega.Expect(status).Should(gomega.Equal(1))
 
@@ -161,11 +170,22 @@ func WatchContainerVolumePercentage() {
 func WatchNodePercentage() {
 	status := 0
 	re := regexp.MustCompile(`ephemeral_storage_node_percentage\{node_name="minikube"}\s+(.+)`)
-	output := requestPrometheusString()
-	match := re.FindAllStringSubmatch(output, -1)
-	floatValue, _ := strconv.ParseFloat(match[0][1], 64)
-	if floatValue < 100.0 {
-		status = 1
+	timeout := time.Second * 180
+	startTime := time.Now()
+	for {
+		if time.Since(startTime) >= timeout {
+			break
+		}
+		output := requestPrometheusString()
+		match := re.FindAllStringSubmatch(output, -1)
+		if match != nil {
+			floatValue, _ := strconv.ParseFloat(match[0][1], 64)
+			if floatValue < 100.0 {
+				status = 1
+				break
+			}
+		}
+		time.Sleep(time.Second)
 	}
 	gomega.Expect(status).Should(gomega.Equal(1))
 
@@ -200,6 +220,9 @@ func getPodUsageSize(podName string) float64 {
 	output := requestPrometheusString()
 	re := regexp.MustCompile(fmt.Sprintf(`ephemeral_storage_pod_usage.+pod_name="%s.+\}\s(.+)`, podName))
 	match := re.FindAllStringSubmatch(output, 2)
+	if match == nil {
+		return 0
+	}
 	currentPodSize, _ := strconv.ParseFloat(match[0][1], 64)
 	return currentPodSize
 }
@@ -208,6 +231,9 @@ func getContainerLimitPercentage(podName string) float64 {
 	output := requestPrometheusString()
 	re := regexp.MustCompile(fmt.Sprintf(`ephemeral_storage_container_limit_percentage.+pod_name="%s.+\}\s(.+)`, podName))
 	match := re.FindAllStringSubmatch(output, 2)
+	if match == nil {
+		return 0
+	}
 	currentPodSize, _ := strconv.ParseFloat(match[0][1], 64)
 	return currentPodSize
 }
@@ -218,6 +244,9 @@ func getContainerVolumeLimitPercentage(podName string) float64 {
 		fmt.Sprintf(`ephemeral_storage_container_volume_limit_percentage.+container="%s",mount_path="\/cache".+\}\s(.+)`,
 			podName))
 	match := re.FindAllStringSubmatch(output, 2)
+	if match == nil {
+		return 0
+	}
 	currentPodSize, _ := strconv.ParseFloat(match[0][1], 64)
 	return currentPodSize
 }
@@ -228,6 +257,9 @@ func getContainerVolumeUsage(podName string) float64 {
 		fmt.Sprintf(`ephemeral_storage_container_volume_usage.+container="%s",mount_path="\/cache".+\}\s(.+)`,
 			podName))
 	match := re.FindAllStringSubmatch(output, 2)
+	if match == nil {
+		return 0
+	}
 	currentPodSize, _ := strconv.ParseFloat(match[0][1], 64)
 	return currentPodSize
 }
@@ -237,6 +269,9 @@ func getContainerRootfsUsedBytes(podName string) float64 {
 	re := regexp.MustCompile(
 		fmt.Sprintf(`ephemeral_storage_container_rootfs_used_bytes.+container="%s".+\}\s(.+)`, podName))
 	match := re.FindAllStringSubmatch(output, 2)
+	if match == nil {
+		return 0
+	}
 	currentPodSize, _ := strconv.ParseFloat(match[0][1], 64)
 	return currentPodSize
 }
@@ -318,6 +353,36 @@ func destroyManyPods() {
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 }
+
+func nodeDisconnect() {
+	cmd := exec.Command("make", "minikube_node2_stop")
+	cmd.Dir = "../.."
+
+	_, err := cmd.Output()
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+}
+
+func nodeReconnect() {
+	cmd := exec.Command("make", "minikube_node2_start")
+	cmd.Dir = "../.."
+
+	_, err := cmd.Output()
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+}
+
+var scalingCheckSlice = []string{
+	"node_name=\"minikube-m02",
+	"ephemeral_storage_container_limit_percentage{container=\"kube-proxy\",node_name=\"minikube-m02\"",
+	"ephemeral_storage_inodes{node_name=\"minikube-m02\"",
+	"ephemeral_storage_inodes_free{node_name=\"minikube-m02\"",
+	"ephemeral_storage_inodes_used{node_name=\"minikube-m02\"",
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	scaleUp()
+})
 
 var _ = ginkgo.Describe("Test Metrics\n", func() {
 
@@ -424,21 +489,34 @@ var _ = ginkgo.Describe("Test Metrics\n", func() {
 		})
 	})
 	ginkgo.Context("Test Scaling\n", func() {
-		checkSlice := []string{
-			"node_name=\"minikube-m02",
-			"ephemeral_storage_container_limit_percentage{container=\"kube-proxy\",node_name=\"minikube-m02\"",
-		}
-		ginkgo.Specify("\nScale up test to make sure pods and nodes are found", func() {
-			scaleUp()
-			checkPrometheus(checkSlice, false)
-		})
-		ginkgo.Specify("\nScale Down test to make sure pods and nodes are evicted", func() {
-			scaleDown()
-			checkPrometheus(checkSlice, true)
+		ginkgo.Specify("\nVerify pods and nodes are found after scale up", func() {
+			checkPrometheus(scalingCheckSlice, false)
 		})
 	})
-	ginkgo.Context("Test Garbage Collection\n", func() {
-		ginkgo.Specify("\nPod GC: Deploy pods, verify metrics exist, delete pods, verify metrics are garbage collected", func() {
+	ginkgo.Context("Test Node Disconnect Inode Leak\n", func() {
+		// Reconnect m02 after the disconnect test so subsequent contexts
+		// (Scrape-Driven Eviction, Scale Down) see a healthy cluster.
+		ginkgo.AfterEach(nodeReconnect)
+		ginkgo.Specify("\nStop node m02, assert EvictPodByNode cleans inode metrics (regression for Bug 1)", func() {
+			nodeDisconnect()
+			// Regression: inode metrics should be ABSENT after node unreachable.
+			// Bug 1 caused EvictPodByNode to skip inodesGaugeVec/inodesFreeGaugeVec/inodesUsedGaugeVec,
+			// leaking these metrics. Bug 1 is now fixed.
+			leakCheckSlice := []string{
+				"ephemeral_storage_inodes{node_name=\"minikube-m02\"",
+				"ephemeral_storage_inodes_free{node_name=\"minikube-m02\"",
+				"ephemeral_storage_inodes_used{node_name=\"minikube-m02\"",
+			}
+			checkPrometheus(leakCheckSlice, true)
+			// Sanity check: node-level metrics ABSENT after EvictPodByNode (proves evict ran).
+			evictCheckSlice := []string{
+				"ephemeral_storage_node_percentage{node_name=\"minikube-m02\"",
+			}
+			checkPrometheus(evictCheckSlice, true)
+		})
+	})
+	ginkgo.Context("Test Scrape-Driven Eviction\n", func() {
+		ginkgo.Specify("\nPod eviction: Deploy pods, verify metrics exist, delete pods, verify metrics are scraped-evicted", func() {
 			// Deploy many pods to create metrics
 			deployManyPods()
 
@@ -458,6 +536,13 @@ var _ = ginkgo.Describe("Test Metrics\n", func() {
 
 			// Verify metrics for many-pods namespace are removed
 			checkPrometheus(manyPodsCheckSlice, true)
+		})
+	})
+	ginkgo.Context("Test Scale Down\n", func() {
+		ginkgo.Specify("\nScale Down test to make sure pods and nodes are evicted", func() {
+			nodeReconnect()
+			scaleDown()
+			checkPrometheus(scalingCheckSlice, true)
 		})
 	})
 })


### PR DESCRIPTION
fix: evict inode metrics in EvictPodByNode to stop leak

## Problem
`EvictPodByNode` deleted pod metrics from 18 gauge vecs but skipped
`inodesGaugeVec`, `inodesFreeGaugeVec`, `inodesUsedGaugeVec`. Whenever a node
went unreachable (kubelet stats fetch failed → backoff exhausted → `n.evict`),
its pods' inode metrics were orphaned and leaked forever. `evictPodByName`
already cleaned all three, so the per-pod eviction path was correct — only the
per-node path was missing them.

Introduced in v1.16.0 (#136) when inode metrics were added; the per-pod eviction
was updated but `EvictPodByNode` was missed.

## Fix
Add the three missing `DeletePartialMatch` calls in `EvictPodByNode`.

## Tests
- Unit regression: `TestRootfsLogsMetrics/evictPodByNode` now asserts inode
  series for the evicted node are cleaned (was asserting the leak).
- e2e regression: new `Test Node Disconnect Inode Leak` does `docker stop`
  minikube-m02 so the leak path is exercised *without* the masking that
  `minikube node delete` causes (node delete also deletes pods → per-pod
  eviction cleans the inodes, hiding the bug). Asserts the 3 inode metrics plus
  node-level metrics are ABSENT after disconnect.
- Added `make minikube_node2_stop/start` targets for the disconnect/reconnect.
- Hardened e2e `Watch*` retry loops (sleep instead of busy-wait, hoist regex
  compile) and added nil-guards to the `get*` helpers (previously panicked on
  missing metrics). `AfterEach(nodeReconnect)` keeps the cluster healthy for
  later specs.

Verified: `make fmt vet gosec test-unit test-helm-render` green; focused e2e
4/4 PASS.
