### PR TITLE
Skip eviction on malformed scrape summaries

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -47,19 +47,11 @@ type ephemeralStorageMetrics struct {
 	}
 }
 
-func setMetrics(nodeName string) {
+func setMetricsFromSummary(nodeName string, content []byte) error {
 	var data ephemeralStorageMetrics
-
-	start := time.Now()
-
-	content, err := Node.Query(nodeName)
-	// Skip node query if there is an error.
-	if err != nil {
-		return
+	if err := json.Unmarshal(content, &data); err != nil {
+		return fmt.Errorf("decode stats summary: %w", err)
 	}
-
-	log.Debug().Msg(fmt.Sprintf("Fetched proxy stats from node : %s", nodeName))
-	_ = json.Unmarshal(content, &data)
 
 	// Evict pods absent from the stats summary for scrapeMissTolerance consecutive scrapes
 	currentPods := make([]string, 0, len(data.Pods))
@@ -83,6 +75,24 @@ func setMetrics(nodeName string) {
 		}
 		Node.SetMetrics(nodeName, availableBytes, capacityBytes)
 		Pod.SetMetrics(podName, podNamespace, nodeName, usedBytes, availableBytes, capacityBytes, inodes, inodesFree, inodesUsed, p.Volumes, p.Containers)
+	}
+
+	return nil
+}
+
+func setMetrics(nodeName string) {
+	start := time.Now()
+
+	content, err := Node.Query(nodeName)
+	// Skip node query if there is an error.
+	if err != nil {
+		return
+	}
+
+	log.Debug().Msg(fmt.Sprintf("Fetched proxy stats from node : %s", nodeName))
+	if err := setMetricsFromSummary(nodeName, content); err != nil {
+		log.Warn().Err(err).Msgf("Failed to decode proxy stats from node: %s", nodeName)
+		return
 	}
 
 	adjustTime := sampleIntervalMill - time.Since(start).Milliseconds()

--- a/cmd/app/main_test.go
+++ b/cmd/app/main_test.go
@@ -127,6 +127,16 @@ func TestEphemeralStorageMetricsUnmarshalMalformed(t *testing.T) {
 	}
 }
 
+func TestSetMetricsFromSummaryRejectsMalformedJSON(t *testing.T) {
+	err := setMetricsFromSummary("test-node", []byte(`{"pods": [`))
+	if err == nil {
+		t.Fatal("expected malformed stats summary to return an error")
+	}
+	if !strings.Contains(err.Error(), "decode stats summary") {
+		t.Fatalf("error = %q, want decode context", err)
+	}
+}
+
 func TestEphemeralStorageMetricsUnmarshalEmpty(t *testing.T) {
 	var data ephemeralStorageMetrics
 	if err := json.Unmarshal([]byte(`{}`), &data); err != nil {


### PR DESCRIPTION
## What

- Decode kubelet stats summaries before updating scrape-driven pod eviction state.
- Return early with a warning when the response body is malformed.
- Cover malformed summary handling with a regression test.

## Why

A truncated or otherwise malformed successful response previously produced an empty pod list. Passing that list to `EvictStalePods` advanced every tracked pod toward eviction even though the scrape itself was invalid.

Fixes #196

## Tests

- `go test ./cmd/app -run TestSetMetricsFromSummaryRejectsMalformedJSON -count=1`
- `make fmt`
- `make vet`
- `make test-unit`
- `PATH=/tmp/k8s-esm-bin:$PATH make test-helm-render`
- `make LOCALBIN=/tmp/k8s-esm-bin gosec`