### PR TITLE
Start node informer after pod metrics initialize

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -24,6 +24,33 @@ var (
 	Pod                pod.Collector
 )
 
+// collectorDeps holds the constructor/wiring functions used to build the
+// node and pod collectors. It exists so tests can substitute recording
+// stand-ins and assert the startup call order deterministically, without
+// standing up a real Kubernetes client or Prometheus registry.
+type collectorDeps struct {
+	newNodeCollector func(int64) node.Node
+	newPodCollector  func(int64) pod.Collector
+	startNodeWatch   func(*node.Node)
+}
+
+var defaultCollectorDeps = collectorDeps{
+	newNodeCollector: node.NewCollector,
+	newPodCollector:  pod.NewCollector,
+	startNodeWatch:   (*node.Node).StartWatch,
+}
+
+// startCollectors wires the node and pod collectors, starting the node
+// watch only after both collectors have been constructed. The pod collector
+// must exist before the node watch begins, since a Deployment-mode watch
+// can deliver node delete events that evict pod metrics.
+func startCollectors(sampleInterval int64, deps collectorDeps) (node.Node, pod.Collector) {
+	n := deps.newNodeCollector(sampleInterval)
+	p := deps.newPodCollector(sampleInterval)
+	deps.startNodeWatch(&n)
+	return n, p
+}
+
 type ephemeralStorageMetrics struct {
 	Node struct {
 		NodeName string `json:"nodeName"`
@@ -142,9 +169,7 @@ func main() {
 
 	dev.SetLogger()
 	dev.SetK8sClient()
-	Node = node.NewCollector(sampleInterval)
-	Pod = pod.NewCollector(sampleInterval)
-	Node.StartWatch()
+	Node, Pod = startCollectors(sampleInterval, defaultCollectorDeps)
 
 	if pprofEnabled {
 		go dev.EnablePprof()

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -144,6 +144,7 @@ func main() {
 	dev.SetK8sClient()
 	Node = node.NewCollector(sampleInterval)
 	Pod = pod.NewCollector(sampleInterval)
+	Node.StartWatch()
 
 	if pprofEnabled {
 		go dev.EnablePprof()

--- a/cmd/app/main_test.go
+++ b/cmd/app/main_test.go
@@ -2,9 +2,45 @@ package main
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/node"
+	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/pod"
 )
+
+// TestStartCollectorsOrdersPodBeforeNodeWatch locks in the guarantee that
+// the diff for #199 depends on: the node watch must not begin until the
+// pod collector exists, since a Deployment-mode watch can deliver node
+// delete events that would otherwise evict pod metrics before they exist.
+// It substitutes recording stand-ins for the real constructors so the call
+// order is asserted deterministically, without a real Kubernetes client or
+// Prometheus registry.
+func TestStartCollectorsOrdersPodBeforeNodeWatch(t *testing.T) {
+	var order []string
+
+	deps := collectorDeps{
+		newNodeCollector: func(int64) node.Node {
+			order = append(order, "node.NewCollector")
+			return node.Node{}
+		},
+		newPodCollector: func(int64) pod.Collector {
+			order = append(order, "pod.NewCollector")
+			return pod.Collector{}
+		},
+		startNodeWatch: func(*node.Node) {
+			order = append(order, "node.StartWatch")
+		},
+	}
+
+	startCollectors(1, deps)
+
+	want := []string{"node.NewCollector", "pod.NewCollector", "node.StartWatch"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("startup order = %v, want %v", order, want)
+	}
+}
 
 const sampleStatsSummary = `{
   "node": {"nodeName": "test-node-01"},

--- a/pkg/node/factory.go
+++ b/pkg/node/factory.go
@@ -70,9 +70,15 @@ func NewCollector(sampleInterval int64) Node {
 
 	if node.deployType != "Deployment" {
 		node.Set.Add(dev.GetEnv("CURRENT_NODE_NAME", ""))
-	} else {
-		go node.Watch()
 	}
 
 	return node
+}
+
+// StartWatch starts the node informer in Deployment mode after dependent
+// metrics are initialized.
+func (n *Node) StartWatch() {
+	if n.deployType == "Deployment" {
+		go n.Watch()
+	}
 }

--- a/pkg/node/factory.go
+++ b/pkg/node/factory.go
@@ -75,10 +75,26 @@ func NewCollector(sampleInterval int64) Node {
 	return node
 }
 
+// watchStarter is the function StartWatch uses to begin watching. It is a
+// package variable so tests can substitute a lightweight stand-in and
+// observe exactly when watching begins, instead of driving a real informer
+// against a Kubernetes API server.
+var watchStarter = func(n *Node) { n.Watch() }
+
+// SetWatchStarter overrides the function StartWatch uses to begin watching
+// and returns a func that restores the previous behavior. It exists so
+// tests can observe StartWatch invocations deterministically without
+// running a real informer.
+func SetWatchStarter(f func(n *Node)) (restore func()) {
+	prev := watchStarter
+	watchStarter = f
+	return func() { watchStarter = prev }
+}
+
 // StartWatch starts the node informer in Deployment mode after dependent
 // metrics are initialized.
 func (n *Node) StartWatch() {
 	if n.deployType == "Deployment" {
-		go n.Watch()
+		go watchStarter(n)
 	}
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -3,12 +3,15 @@ package node
 import (
 	"math"
 	"os"
+	"os/exec"
 	"sync"
 	"testing"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	dto "github.com/prometheus/client_model/go"
 
+	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/dev"
 	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/pod"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -209,4 +212,25 @@ func TestNode(t *testing.T) {
 			t.Error("keep-node should still be in Set")
 		}
 	})
+}
+
+func TestNewCollectorDeploymentDefersWatch(t *testing.T) {
+	const helperEnv = "TEST_NEW_COLLECTOR_DEFERS_WATCH"
+	if os.Getenv(helperEnv) == "1" {
+		registry := prometheus.NewRegistry()
+		prometheus.DefaultRegisterer = registry
+		prometheus.DefaultGatherer = registry
+		dev.Clientset = nil
+		t.Setenv("DEPLOY_TYPE", "Deployment")
+
+		_ = NewCollector(1)
+		time.Sleep(100 * time.Millisecond)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestNewCollectorDeploymentDefersWatch$")
+	cmd.Env = append(os.Environ(), helperEnv+"=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("NewCollector started the node watcher before pod initialization: %v\n%s", err, output)
+	}
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -3,7 +3,6 @@ package node
 import (
 	"math"
 	"os"
-	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -11,7 +10,6 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/dev"
 	"github.com/jmcgrath207/k8s-ephemeral-storage-metrics/pkg/pod"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -215,22 +213,35 @@ func TestNode(t *testing.T) {
 }
 
 func TestNewCollectorDeploymentDefersWatch(t *testing.T) {
-	const helperEnv = "TEST_NEW_COLLECTOR_DEFERS_WATCH"
-	if os.Getenv(helperEnv) == "1" {
-		registry := prometheus.NewRegistry()
-		prometheus.DefaultRegisterer = registry
-		prometheus.DefaultGatherer = registry
-		dev.Clientset = nil
-		t.Setenv("DEPLOY_TYPE", "Deployment")
+	registry := prometheus.NewRegistry()
+	origRegisterer, origGatherer := prometheus.DefaultRegisterer, prometheus.DefaultGatherer
+	prometheus.DefaultRegisterer = registry
+	prometheus.DefaultGatherer = registry
+	t.Cleanup(func() {
+		prometheus.DefaultRegisterer = origRegisterer
+		prometheus.DefaultGatherer = origGatherer
+	})
 
-		_ = NewCollector(1)
-		time.Sleep(100 * time.Millisecond)
-		return
+	watched := make(chan struct{}, 1)
+	restore := SetWatchStarter(func(*Node) { watched <- struct{}{} })
+	t.Cleanup(restore)
+
+	t.Setenv("DEPLOY_TYPE", "Deployment")
+	n := NewCollector(1)
+
+	select {
+	case <-watched:
+		t.Fatal("NewCollector started the node watch before StartWatch was called")
+	case <-time.After(150 * time.Millisecond):
+		// expected: NewCollector must not begin watching on its own.
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestNewCollectorDeploymentDefersWatch$")
-	cmd.Env = append(os.Environ(), helperEnv+"=1")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("NewCollector started the node watcher before pod initialization: %v\n%s", err, output)
+	n.StartWatch()
+
+	select {
+	case <-watched:
+		// expected: StartWatch wires up the watch loop.
+	case <-time.After(time.Second):
+		t.Fatal("StartWatch did not start the node watch within timeout")
 	}
 }


### PR DESCRIPTION
## What

- Separate Deployment-mode node watcher startup from node collector construction.
- Start the node watcher only after `pod.NewCollector` has initialized the shared pod metrics.
- Add a regression test that verifies `node.NewCollector` does not start informer work on its own.

## Why

The informer could deliver a node deletion between node and pod collector construction. That path calls pod metric eviction while the pod gauge vectors are still nil, causing a startup panic.

Fixes #199

## Tests

- `go test ./pkg/node -run TestNewCollectorDeploymentDefersWatch -count=1`
- `make fmt`
- `make vet`
- `make test-unit`
- `PATH=/tmp/k8s-esm-bin:$PATH make test-helm-render`
- `make LOCALBIN=/tmp/k8s-esm-bin gosec`