### PR TITLE
update default deploy type to DaemonSet and bump chart version to 1.21.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,13 @@ release-helm:
 
 release: release-docker release-helm helm-docs
 	# Prod release
-	# ex. make VERSION=1.21.2 release
+	# ex. make VERSION=1.21.3 release
 	# Prerelease Candidate
 	# ex. make VERSION=1.11.2-rc01 release
 
 release-github:
 	# Prod release
-	# ex. make VERSION=1.21.2 release-github
+	# ex. make VERSION=1.21.3 release-github
 	gh repo set-default jmcgrath207/k8s-ephemeral-storage-metrics
 	gh release create ${VERSION} --generate-notes
 	gh release upload ${VERSION} "chart/k8s-ephemeral-storage-metrics-${VERSION}.tgz"

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Every metric carries `node_name`. Pod/container metrics add `pod_name`, `pod_nam
 
 ### DaemonSet vs Deployment
 
-- **Deployment** (default): single controller, lists all pods/nodes. Use `deploy_type: Deployment` plus optional `node_label_selector` to filter nodes (e.g. `type=virtual-kubelet` to exclude virtual nodes).
-- **DaemonSet**: one exporter per node, scrapes local kubelet. Lighter apiserver load. Set `deploy_type: DaemonSet`.
+- **DaemonSet** (default): one exporter per node, scrapes local kubelet. Lighter apiserver load. Set `deploy_type: DaemonSet`.
+- **Deployment**: single controller, lists all pods/nodes. Use `deploy_type: Deployment` plus optional `node_label_selector` to filter nodes (e.g. `type=virtual-kubelet` to exclude virtual nodes).
 
 For large clusters (2K+ nodes), set `list_pods_with_cache: true` to read pod lists from the apiserver cache and reduce apiserver pressure. Pair with `deploy_type: DaemonSet` so each pod only lists its own node's pods (`spec.nodeName` fieldSelector).
 
@@ -69,7 +69,7 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.imagePullSecrets | list | `[]` |  |
 | image.repository | string | `"ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics"` |  |
-| image.tag | string | `"1.21.2"` |  |
+| image.tag | string | `"1.21.3"` |  |
 | interval | int | `15` | Polling node rate for exporter |
 | kubeconfig | string | `""` | Path to kubeconfig file; leave empty for in-cluster config |
 | kubelet | object | `{"insecure":false,"readOnlyPort":0,"scrape":false}` | Scrape metrics through kubelet instead of kube api |

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k8s-ephemeral-storage-metrics
-version: 1.21.2
-appVersion: 1.21.2
+version: 1.21.3
+appVersion: 1.21.3
 kubeVersion: ">=1.21.0-0"
 description: Ephemeral storage metrics for prometheus operator.
 home: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics

--- a/chart/README.md
+++ b/chart/README.md
@@ -25,7 +25,7 @@ helm upgrade --install my-deployment k8s-ephemeral-storage-metrics/k8s-ephemeral
 | image.imagePullPolicy | string | `"IfNotPresent"` |  |
 | image.imagePullSecrets | list | `[]` |  |
 | image.repository | string | `"ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics"` |  |
-| image.tag | string | `"1.21.2"` |  |
+| image.tag | string | `"1.21.3"` |  |
 | interval | int | `15` | Polling node rate for exporter |
 | kubeconfig | string | `""` | Path to kubeconfig file; leave empty for in-cluster config |
 | kubelet | object | `{"insecure":false,"readOnlyPort":0,"scrape":false}` | Scrape metrics through kubelet instead of kube api |

--- a/chart/index.yaml
+++ b/chart/index.yaml
@@ -8,10 +8,10 @@ entries:
           url: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
       artifacthub.io/prerelease: "false"
     apiVersion: v2
-    appVersion: 1.21.2
-    created: "2026-07-16T08:23:14.847369723-05:00"
+    appVersion: 1.21.3
+    created: "2026-07-16T08:42:12.877237404-05:00"
     description: Ephemeral storage metrics for prometheus operator.
-    digest: 84e252d3ab556acd345b26ff64e19ae61c394f4dca649894368fb95242614252
+    digest: 64f916134aeb805b41bc3245beb05384c4637c6e0a37418a4f3830743b07ef8d
     home: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
     keywords:
     - kubernetes
@@ -21,7 +21,29 @@ entries:
     sources:
     - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
     urls:
-    - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/releases/download/1.21.2/k8s-ephemeral-storage-metrics-1.21.2.tgz
+    - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/releases/download/1.21.3/k8s-ephemeral-storage-metrics-1.21.3.tgz
+    version: 1.21.3
+  - annotations:
+      artifacthub.io/license: MIT
+      artifacthub.io/links: |
+        - name: Documentation
+          url: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+      artifacthub.io/prerelease: "false"
+    apiVersion: v2
+    appVersion: 1.21.2
+    created: "2026-07-16T08:42:12.87631884-05:00"
+    description: Ephemeral storage metrics for prometheus operator.
+    digest: d0cf8267c4a12d709fbcc2ebafb0928af118cc16442e4851107763656a90146a
+    home: https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+    keywords:
+    - kubernetes
+    - metrics
+    kubeVersion: '>=1.21.0-0'
+    name: k8s-ephemeral-storage-metrics
+    sources:
+    - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics
+    urls:
+    - k8s-ephemeral-storage-metrics-1.21.2.tgz
     version: 1.21.2
   - annotations:
       artifacthub.io/license: MIT
@@ -1189,4 +1211,4 @@ entries:
     urls:
     - https://github.com/jmcgrath207/k8s-ephemeral-storage-metrics/releases/download/1.0.0/k8s-ephemeral-storage-metrics-1.0.0.tgz
     version: 1.0.0
-generated: "2026-07-16T08:23:14.84661104-05:00"
+generated: "2026-07-16T08:42:12.875167434-05:00"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: ""
 
 image:
   repository: ghcr.io/jmcgrath207/k8s-ephemeral-storage-metrics
-  tag: 1.21.2
+  tag: 1.21.3
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
## Pre-PR
- [ ] `make fmt vet test-unit test-helm-render` passes
- [ ] Added unit and e2e regression tests, or explained why not feasible
- [ ] No metric renames/relabels/type-changes
- [ ] No version bumps (Go, modules, chart, tools, Actions)
